### PR TITLE
feat: add reading progress indicator to blog posts

### DIFF
--- a/src/components/ReadingProgress.astro
+++ b/src/components/ReadingProgress.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * Reading Progress Indicator
+ * Displays a horizontal progress bar at the top of the page
+ * that fills as the user scrolls through the content
+ */
+---
+
+<div id="reading-progress-container" class="fixed top-0 left-0 right-0 z-50 h-[3px]">
+  <div
+    id="reading-progress-bar"
+    class="h-full bg-primary origin-left transition-transform duration-150 ease-out shadow-sm"
+    style="transform: scaleX(0);"
+  >
+  </div>
+</div>
+
+<script>
+  class ReadingProgressState {
+    progressBar: HTMLElement | null = null;
+
+    reset() {
+      this.progressBar = document.getElementById("reading-progress-bar");
+      if (this.progressBar) {
+        this.progressBar.style.transform = "scaleX(0)";
+      }
+    }
+  }
+
+  const state = new ReadingProgressState();
+
+  class ReadingProgressController {
+    static updateProgress() {
+      if (!state.progressBar) return;
+
+      const scrollableDistance = document.documentElement.scrollHeight - window.innerHeight;
+      const scrollProgress =
+        scrollableDistance > 0 ? Math.min(Math.max(window.scrollY / scrollableDistance, 0), 1) : 0;
+
+      state.progressBar.style.transform = `scaleX(${scrollProgress})`;
+    }
+
+    static init() {
+      state.reset();
+
+      if (!state.progressBar) return;
+
+      // Update on scroll
+      window.addEventListener("scroll", this.updateProgress, { passive: true });
+
+      // Update on resize (content height might change)
+      window.addEventListener("resize", this.updateProgress, { passive: true });
+
+      // Initial update
+      this.updateProgress();
+    }
+
+    static cleanup() {
+      window.removeEventListener("scroll", this.updateProgress);
+      window.removeEventListener("resize", this.updateProgress);
+    }
+  }
+
+  // Initialize on page load
+  document.addEventListener("astro:page-load", () => ReadingProgressController.init());
+
+  // Re-initialize after view transitions
+  document.addEventListener("astro:after-swap", () => {
+    ReadingProgressController.cleanup();
+    ReadingProgressController.init();
+  });
+
+  // Cleanup before view transitions
+  document.addEventListener("astro:before-swap", () => ReadingProgressController.cleanup());
+</script>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
+import ReadingProgress from "@/components/ReadingProgress.astro";
 import TOCHeader from "@/components/TOCHeader.astro";
 import TOCSidebar from "@/components/TOCSidebar.astro";
 import { SITE } from "@/consts";
@@ -57,6 +58,7 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
     },
   }}
 >
+  <ReadingProgress />
   <Header slot="header" />
   {tocHeadings.length > 0 && <TOCHeader slot="table-of-contents" headings={tocHeadings} />}
 


### PR DESCRIPTION
## Summary
Adds a horizontal reading progress bar at the top of blog post pages that smoothly animates as users scroll through content.

## Changes
- Created `ReadingProgress.astro` component with scroll tracking
- Integrated component into blog post layout
- Progress bar uses theme-aware primary color
- Smooth CSS transform-based animation for performance
- Compatible with Astro view transitions

## Implementation Details
- **Height**: 3px (subtle, minimalist design)
- **Position**: Fixed at top of page
- **Color**: Uses `bg-primary` (automatically adapts to light/dark theme)
- **Performance**: Passive scroll listeners + GPU-accelerated transforms
- **Shadow**: Subtle shadow for better visibility on all backgrounds

## Testing
- ✅ ESLint passed
- ✅ Prettier formatting passed
- ✅ TypeScript validation passed
- ✅ Build successful

## Closes
Closes #18

## Preview
The reading progress bar will be visible on all blog post pages at the very top. It fills from left to right as you scroll down the page.