### PR TITLE
feat: add related posts recommendations

### DIFF
--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,60 @@
+---
+import Link from "@/components/Link.astro";
+import { formatBlogDate } from "@/lib/utils";
+import { type CollectionEntry } from "astro:content";
+import { Calendar } from "lucide-astro";
+
+interface Props {
+  posts: CollectionEntry<"blog">[];
+  class?: string;
+}
+
+const { posts, class: className } = Astro.props;
+---
+
+{
+  posts.length > 0 && (
+    <section class:list={["mt-12 pt-8 border-t border-border", className]}>
+      <h2 class="text-2xl font-bold text-foreground mb-6">Related Posts</h2>
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => {
+          const { title, description, publishDate, tags } = post.data;
+          const formattedDate = formatBlogDate(publishDate);
+
+          return (
+            <article class="flex flex-col gap-3 p-4 rounded-lg border border-border bg-card hover:bg-muted/50 transition-colors group">
+              <Link href={`/blog/${post.slug}`} class="flex flex-col gap-3 no-underline">
+                <div class="flex flex-col gap-2">
+                  <h3 class="text-lg font-semibold text-foreground group-hover:text-primary transition-colors line-clamp-2">
+                    {title}
+                  </h3>
+                  <p class="text-sm text-muted-foreground line-clamp-2">{description}</p>
+                </div>
+
+                <div class="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Calendar size={14} />
+                  <time datetime={publishDate.toISOString()}>{formattedDate}</time>
+                </div>
+
+                {tags.length > 0 && (
+                  <div class="flex flex-wrap gap-1.5">
+                    {tags.slice(0, 3).map((tag) => (
+                      <span class="text-xs px-2 py-1 bg-muted text-muted-foreground rounded-md">
+                        {tag}
+                      </span>
+                    ))}
+                    {tags.length > 3 && (
+                      <span class="text-xs px-2 py-1 text-muted-foreground">
+                        +{tags.length - 3}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </Link>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/lib/recommendations.ts
+++ b/src/lib/recommendations.ts
@@ -1,0 +1,76 @@
+import { type CollectionEntry, getCollection } from "astro:content";
+
+type BlogPost = CollectionEntry<"blog">;
+
+/**
+ * Calculate similarity score between two blog posts based on shared tags
+ */
+function calculateSimilarity(currentPost: BlogPost, otherPost: BlogPost): number {
+  const currentTags = new Set(currentPost.data.tags);
+  const otherTags = otherPost.data.tags;
+
+  // Count matching tags
+  const matchingTags = otherTags.filter((tag) => currentTags.has(tag)).length;
+
+  // Similarity score: number of matching tags
+  return matchingTags;
+}
+
+/**
+ * Get related posts based on tag similarity
+ * @param currentPostSlug - Slug of the current blog post
+ * @param limit - Maximum number of related posts to return (default: 3)
+ * @returns Array of related blog posts sorted by relevance
+ */
+export async function getRelatedPosts(
+  currentPostSlug: string,
+  limit: number = 3
+): Promise<BlogPost[]> {
+  // Get all published blog posts
+  const allPosts = await getCollection("blog", (post) => !post.data.draft);
+
+  // Find the current post
+  const currentPost = allPosts.find((post) => post.slug === currentPostSlug);
+
+  if (!currentPost) {
+    return [];
+  }
+
+  // Calculate similarity scores for all other posts
+  const postsWithScores = allPosts
+    .filter((post) => post.slug !== currentPostSlug) // Exclude current post
+    .map((post) => ({
+      post,
+      score: calculateSimilarity(currentPost, post),
+      date: post.data.publishDate.valueOf(),
+    }))
+    .filter((item) => item.score > 0) // Only include posts with at least one matching tag
+    .sort((a, b) => {
+      // Sort by similarity score first (descending)
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      // If scores are equal, sort by date (newest first)
+      return b.date - a.date;
+    });
+
+  // If we don't have enough related posts with matching tags, fill with recent posts
+  if (postsWithScores.length < limit) {
+    const remainingSlots = limit - postsWithScores.length;
+    const existingSlugs = new Set([
+      currentPostSlug,
+      ...postsWithScores.map((item) => item.post.slug),
+    ]);
+
+    const recentPosts = allPosts
+      .filter((post) => !existingSlugs.has(post.slug))
+      .sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf())
+      .slice(0, remainingSlots)
+      .map((post) => ({ post, score: 0, date: post.data.publishDate.valueOf() }));
+
+    postsWithScores.push(...recentPosts);
+  }
+
+  // Return limited number of posts
+  return postsWithScores.slice(0, limit).map((item) => item.post);
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,10 +2,12 @@
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
 import ReadingProgress from "@/components/ReadingProgress.astro";
+import RelatedPosts from "@/components/RelatedPosts.astro";
 import TOCHeader from "@/components/TOCHeader.astro";
 import TOCSidebar from "@/components/TOCSidebar.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
+import { getRelatedPosts } from "@/lib/recommendations";
 import { calculateReadingTime, cn, formatBlogDate, formatReadingTime } from "@/lib/utils";
 import { type CollectionEntry, getCollection } from "astro:content";
 import { Calendar, Clock } from "lucide-astro";
@@ -32,6 +34,9 @@ const readingTime = calculateReadingTime(post.body ?? "");
 
 // Filter headings for TOC (h2 and h3 only)
 const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
+
+// Get related posts
+const relatedPosts = await getRelatedPosts(post.slug, 3);
 ---
 
 <Layout
@@ -135,6 +140,11 @@ const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
     <article class="prose col-start-2 max-w-none px-4">
       <Content />
     </article>
+
+    {/* Related Posts */}
+    <div class="col-start-2 px-4">
+      <RelatedPosts posts={relatedPosts} />
+    </div>
 
     {/* Back to Blog */}
     <div class="col-start-2 pt-6 border-t border-border px-4">


### PR DESCRIPTION
## Summary

Implements related posts recommendations at the end of blog posts to increase engagement.

Closes #15

## Changes

### New Files Created

- **`src/lib/recommendations.ts`**: Recommendation engine with tag-based similarity scoring
  - `getRelatedPosts()` function that finds similar posts based on shared tags
  - Falls back to recent posts if not enough tag matches
  - Configurable limit (default: 3 posts)
  - Excludes current post and drafts

- **`src/components/RelatedPosts.astro`**: Component to display related posts
  - Responsive grid layout (1 column mobile, 2-3 columns desktop)
  - Shows post title, description, date, and tags
  - Hover effects and smooth transitions
  - Line-clamping for text overflow
  - Tag overflow indicator (+N more)

### Files Modified

- **`src/pages/blog/[...slug].astro`**: Integrated RelatedPosts component
  - Fetches related posts using recommendation engine
  - Displays between content and "Back to Blog" link
  - Maintains consistent grid layout

## Implementation Details

### Recommendation Algorithm

1. **Tag-based similarity**: Calculates score based on number of shared tags
2. **Sorting**: First by similarity score (descending), then by date (newest first)
3. **Fallback**: If fewer matches than limit, fills with recent posts
4. **Filtering**: Excludes current post and draft posts

### Design

- Consistent with existing design system
- Responsive grid layout
- Hover states for better UX
- Clean card-based presentation
- Proper spacing and typography

## Testing

- ✅ Build completes successfully (all 12 blog posts generated)
- ✅ ESLint passes with no warnings
- ✅ Prettier formatting validated
- ✅ TypeScript compilation succeeds
- ✅ Pre-commit hooks pass

## Screenshots

Related posts will appear at the bottom of each blog post, showing up to 3 relevant posts based on shared tags.