### PR TITLE
Simplify About Page Layout

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -40,7 +40,7 @@ export const AUTHOR = {
   longBio:
     "I enjoy working on challenging problems and learning new technologies. When I'm not coding, you can find me contributing to open source, writing technical articles, or exploring new frameworks and tools.",
   avatar: "/avatar.jpg",
-  location: "India",
+  location: "Kochi, Kerala, India",
   usernameOrigin:
     "My username 'abijith' is simply my first name. I prefer to keep things simple and authentic in the digital world.",
 } as const;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,10 +1,9 @@
 ---
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
-import Skills from "@/components/Skills.astro";
 import Timeline from "@/components/Timeline.astro";
 import { AUTHOR, SITE, SOCIAL_LINKS } from "@/consts";
-import { EDUCATION, EXPERIENCE, SKILLS } from "@/data/about";
+import { EDUCATION } from "@/data/about";
 import Layout from "@/layouts/Layout.astro";
 import { Github, Linkedin, MapPin } from "lucide-astro";
 ---
@@ -39,28 +38,12 @@ import { Github, Linkedin, MapPin } from "lucide-astro";
       <div class="flex-1 space-y-3">
         <h1 class="text-3xl font-bold">{AUTHOR.name}</h1>
 
-        <div class="flex flex-col gap-1 text-muted-foreground">
-          <span>@{AUTHOR.username}</span>
-
-          {
-            AUTHOR.location && (
-              <span class="flex items-center gap-1">
-                <MapPin size={14} />
-                {AUTHOR.location}
-              </span>
-            )
-          }
-        </div>
-
-        <!-- Username origin -->
         {
-          AUTHOR.usernameOrigin && (
-            <details class="text-sm">
-              <summary class="cursor-pointer text-muted-foreground hover:text-foreground">
-                Username origin
-              </summary>
-              <p class="mt-2 text-muted-foreground">{AUTHOR.usernameOrigin}</p>
-            </details>
+          AUTHOR.location && (
+            <span class="flex items-center gap-1 text-muted-foreground">
+              <MapPin size={14} />
+              {AUTHOR.location}
+            </span>
           )
         }
       </div>
@@ -102,22 +85,10 @@ import { Github, Linkedin, MapPin } from "lucide-astro";
       </Link>
     </section>
 
-    <!-- Work Experience -->
-    <section class="flex flex-col gap-y-4">
-      <h2 class="text-2xl font-bold">Experience</h2>
-      <Timeline items={EXPERIENCE} />
-    </section>
-
     <!-- Education -->
     <section class="flex flex-col gap-y-4">
       <h2 class="text-2xl font-bold">Education</h2>
       <Timeline items={EDUCATION} />
-    </section>
-
-    <!-- Skills -->
-    <section class="flex flex-col gap-y-4">
-      <h2 class="text-2xl font-bold">Skills & Technologies</h2>
-      <Skills categories={SKILLS} />
     </section>
   </main>
 </Layout>


### PR DESCRIPTION
## Summary

This PR simplifies the About page by removing unnecessary sections and updating location information.

### Changes Made

- **Updated Location**: Changed from "India" to "Kochi, Kerala, India"
- **Removed Username Display**: Removed @username from profile header
- **Removed Username Origin**: Removed collapsible username origin section
- **Removed Experience Section**: Removed work experience timeline
- **Removed Skills Section**: Removed skills grid

### What Remains

The About page now contains only:
- Profile header with avatar, name, and location
- Bio section
- Quick links (GitHub and LinkedIn)
- Education section

### Testing

- ✅ Lint checks passed
- ✅ Production build successful
- ✅ Page structure simplified as requested