### PR TITLE
feat: add Pagefind search functionality

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -54,5 +54,14 @@ export default defineConfig({
       // Pre-bundle these dependencies
       include: ["clsx", "tailwind-merge"],
     },
+    build: {
+      rollupOptions: {
+        onwarn(warning, warn) {
+          // Suppress warnings about unused imports from Astro internals
+          if (warning.code === "UNUSED_EXTERNAL_IMPORT") return;
+          warn(warning);
+        },
+      },
+    },
   },
 });

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@pagefind/default-ui": "^1.4.0",
         "@tailwindcss/vite": "^4.1.18",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
@@ -25,6 +26,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.10",
+        "pagefind": "^1.4.0",
         "prettier": "^3.7.4",
         "prettier-plugin-astro": "^0.14.1",
         "tailwindcss": "^4.1.18",
@@ -218,6 +220,20 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ=="],
+
+    "@pagefind/darwin-x64": ["@pagefind/darwin-x64@1.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A=="],
+
+    "@pagefind/default-ui": ["@pagefind/default-ui@1.4.0", "", {}, "sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ=="],
+
+    "@pagefind/freebsd-x64": ["@pagefind/freebsd-x64@1.4.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q=="],
+
+    "@pagefind/linux-arm64": ["@pagefind/linux-arm64@1.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw=="],
+
+    "@pagefind/linux-x64": ["@pagefind/linux-x64@1.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg=="],
+
+    "@pagefind/windows-x64": ["@pagefind/windows-x64@1.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
@@ -1092,6 +1108,8 @@
     "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "pagefind": ["pagefind@1.4.0", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.4.0", "@pagefind/darwin-x64": "1.4.0", "@pagefind/freebsd-x64": "1.4.0", "@pagefind/linux-arm64": "1.4.0", "@pagefind/linux-x64": "1.4.0", "@pagefind/windows-x64": "1.4.0" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g=="],
 
     "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "lint": "eslint .",
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@pagefind/default-ui": "^1.4.0",
     "@tailwindcss/vite": "^4.1.18",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
@@ -34,6 +35,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.10",
+    "pagefind": "^1.4.0",
     "prettier": "^3.7.4",
     "prettier-plugin-astro": "^0.14.1",
     "tailwindcss": "^4.1.18",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -22,6 +22,7 @@ export const NAV_LINKS = [
   { href: "/projects", label: "Projects" },
   { href: "/blog", label: "Blog" },
   { href: "/about", label: "About" },
+  { href: "/search", label: "Search" },
 ] as const;
 
 // Social Links

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,94 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import Header from "@/components/Header.astro";
+---
+
+<Layout
+  title="Search"
+  description="Search blog posts and projects"
+  jsonLd={{
+    type: "WebPage",
+    name: "Search",
+  }}
+>
+  <Header slot="header" />
+
+  <div class="mx-auto max-w-3xl">
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold tracking-tight">Search</h1>
+      <p class="mt-2 text-muted-foreground">Find blog posts and projects</p>
+    </div>
+
+    <div id="search"></div>
+  </div>
+</Layout>
+
+<style is:global>
+  :root {
+    --pagefind-ui-scale: 1;
+    --pagefind-ui-primary: var(--primary);
+    --pagefind-ui-text: var(--foreground);
+    --pagefind-ui-background: var(--background);
+    --pagefind-ui-border: var(--border);
+    --pagefind-ui-tag: var(--muted);
+    --pagefind-ui-border-width: 1px;
+    --pagefind-ui-border-radius: 0.5rem;
+    --pagefind-ui-image-border-radius: 0.5rem;
+    --pagefind-ui-image-box-ratio: 3 / 2;
+    --pagefind-ui-font: inherit;
+  }
+
+  .pagefind-ui__search-input {
+    background-color: var(--background);
+    border: 1px solid var(--border);
+    color: var(--foreground);
+  }
+
+  .pagefind-ui__search-input:focus {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+
+  .pagefind-ui__result {
+    border: 1px solid var(--border);
+    background-color: var(--card);
+  }
+
+  .pagefind-ui__result:hover {
+    background-color: var(--muted);
+  }
+
+  .pagefind-ui__result-title {
+    color: var(--foreground);
+  }
+
+  .pagefind-ui__result-excerpt {
+    color: var(--muted-foreground);
+  }
+
+  .pagefind-ui__message {
+    color: var(--muted-foreground);
+  }
+
+  .pagefind-ui__button {
+    background-color: var(--primary);
+    color: var(--primary-foreground);
+    border: none;
+  }
+
+  .pagefind-ui__button:hover {
+    opacity: 0.9;
+  }
+</style>
+
+<script>
+  import { PagefindUI } from "@pagefind/default-ui";
+
+  // Initialize Pagefind UI
+  new PagefindUI({
+    element: "#search",
+    showImages: false,
+    highlightParam: "highlight",
+    excerptLength: 30,
+  });
+</script>


### PR DESCRIPTION
## Summary
- Add Pagefind search for blog posts and projects
- Suppress vite warnings about unused imports
- Install pagefind and @pagefind/default-ui packages
- Create search page with theme-aware styling
- Add search link to navigation

Closes #14