### PR TITLE
feat: add breadcrumbs to all pages

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,32 @@
+---
+import Link from "@/components/Link.astro";
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface Props {
+  items: BreadcrumbItem[];
+  class?: string;
+}
+
+const { items, class: className } = Astro.props;
+---
+
+<nav class:list={["flex items-center gap-2 text-sm text-muted-foreground", className]}>
+  {
+    items.map((item, index) => (
+      <>
+        {item.href ? (
+          <Link href={item.href} class="hover:text-foreground transition-colors">
+            {item.label}
+          </Link>
+        ) : (
+          <span class="text-foreground truncate">{item.label}</span>
+        )}
+        {index < items.length - 1 && <span>/</span>}
+      </>
+    ))
+  }
+</nav>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,4 +1,5 @@
 ---
+import Breadcrumb from "@/components/Breadcrumb.astro";
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
 import { AUTHOR, SITE, SOCIAL_LINKS } from "@/consts";
@@ -14,12 +15,7 @@ import { Github, Linkedin, MapPin } from "lucide-astro";
 >
   <Header slot="header" />
   <main class="w-full mx-auto flex grow flex-col gap-y-12 px-4 max-w-3xl pb-12">
-    <!-- Breadcrumb -->
-    <nav class="flex items-center gap-2 text-sm text-muted-foreground">
-      <Link href="/">Home</Link>
-      <span>/</span>
-      <span class="text-foreground">About</span>
-    </nav>
+    <Breadcrumb items={[{ label: "Home", href: "/" }, { label: "About" }]} />
 
     <!-- Profile Header -->
     <section class="flex flex-col md:flex-row gap-6 items-center md:items-center">

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,5 +1,6 @@
 ---
 import BlogCard from "@/components/BlogCard.astro";
+import Breadcrumb from "@/components/Breadcrumb.astro";
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
 import { SITE } from "@/consts";
@@ -46,6 +47,8 @@ const nextUrl = hasNext ? `/blog/${currentPage + 1}` : null;
 >
   <Header slot="header" />
   <main class="w-full mx-auto flex grow flex-col gap-y-8 px-4 max-w-3xl pb-12">
+    <Breadcrumb items={[{ label: "Home", href: "/" }, { label: "Blog" }]} />
+
     <div class="flex flex-col gap-y-2">
       <h1 class="text-3xl font-bold text-foreground">Blog</h1>
       <p class="text-muted-foreground">

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -1,4 +1,5 @@
 ---
+import Breadcrumb from "@/components/Breadcrumb.astro";
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
 import ProjectCard from "@/components/ProjectCard.astro";
@@ -46,6 +47,8 @@ const nextUrl = hasNext ? `/projects/${currentPage + 1}` : null;
 >
   <Header slot="header" />
   <main class="w-full mx-auto flex grow flex-col gap-y-8 px-4 max-w-3xl pb-12">
+    <Breadcrumb items={[{ label: "Home", href: "/" }, { label: "Projects" }]} />
+
     <div class="flex flex-col gap-y-2">
       <h1 class="text-3xl font-bold text-foreground">Projects</h1>
       <p class="text-muted-foreground">


### PR DESCRIPTION
## Summary
- Create reusable Breadcrumb component for consistent navigation
- Add breadcrumbs to About page (Home / About)
- Add breadcrumbs to Blog listing page (Home / Blog)
- Add breadcrumbs to Projects listing page (Home / Projects)
- Use consistent styling matching existing breadcrumbs

Closes #43