### PR TITLE
Implement All Tags Page for Tag Discovery (#41)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -21,6 +21,7 @@ export const SITE = {
 export const NAV_LINKS = [
   { href: "/projects", label: "Projects" },
   { href: "/blog", label: "Blog" },
+  { href: "/tags", label: "Tags" },
   { href: "/about", label: "About" },
   { href: "/search", label: "Search" },
 ] as const;

--- a/src/lib/data-utils.ts
+++ b/src/lib/data-utils.ts
@@ -92,6 +92,27 @@ export async function getAllBlogTags(): Promise<string[]> {
 }
 
 /**
+ * Get all unique tags from blog posts with counts
+ */
+export async function getAllBlogTagsWithCount(): Promise<Array<{ tag: string; count: number }>> {
+  const posts = await getCollection("blog");
+  const tagCounts = new Map<string, number>();
+
+  // Filter out drafts
+  const publishedPosts = posts.filter((post) => !post.data.draft);
+
+  publishedPosts.forEach((post) => {
+    post.data.tags.forEach((tag) => {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    });
+  });
+
+  return Array.from(tagCounts.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => a.tag.localeCompare(b.tag));
+}
+
+/**
  * Format project date range
  */
 export function formatProjectDate(startDate: Date, endDate?: Date): string {

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,83 @@
+---
+import Header from "@/components/Header.astro";
+import Link from "@/components/Link.astro";
+import { SITE } from "@/consts";
+import Layout from "@/layouts/Layout.astro";
+import { getAllBlogTagsWithCount } from "@/lib/data-utils";
+import { Tag as TagIcon } from "lucide-astro";
+
+const tags = await getAllBlogTagsWithCount();
+---
+
+<Layout
+  title={`All Tags - Blog - ${SITE.title}`}
+  description="Browse all blog posts by topic. Explore tags and discover content that interests you."
+>
+  <Header slot="header" />
+  <main class="w-full mx-auto flex grow flex-col gap-y-8 px-4 max-w-3xl pb-12">
+    <!-- Breadcrumb -->
+    <nav class="flex items-center gap-2 text-sm text-muted-foreground">
+      <Link href="/" class="hover:text-foreground transition-colors">Home</Link>
+      <span>/</span>
+      <Link href="/blog" class="hover:text-foreground transition-colors">Blog</Link>
+      <span>/</span>
+      <span class="text-foreground">Tags</span>
+    </nav>
+
+    <!-- Header -->
+    <div class="flex flex-col gap-y-3">
+      <div class="flex items-center gap-3">
+        <div class="p-2 bg-muted rounded-md">
+          <TagIcon size={20} class="text-muted-foreground" />
+        </div>
+        <div>
+          <h1 class="text-3xl font-bold text-foreground">All Tags</h1>
+          <p class="text-sm text-muted-foreground">Browse posts by topic</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Tags Grid -->
+    {
+      tags.length > 0 ? (
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+          {tags.map(({ tag, count }) => (
+            <Link
+              href={`/tags/${tag}`}
+              class="flex items-center justify-between px-3 py-2 bg-muted hover:bg-muted/80 text-foreground rounded-md transition-colors group"
+            >
+              <span class="text-sm truncate group-hover:text-primary transition-colors">{tag}</span>
+              <span class="text-xs text-muted-foreground ml-2 flex-shrink-0">({count})</span>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <p class="text-muted-foreground text-center py-8">No tags found.</p>
+      )
+    }
+
+    <!-- Back to Blog -->
+    <div class="pt-6 border-t border-border">
+      <Link
+        href="/blog"
+        class="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 12L6 8L10 4"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"></path>
+        </svg>
+        Back to Blog
+      </Link>
+    </div>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- Implements a dedicated `/tags` page displaying all blog tags with post counts
- Adds `getAllBlogTagsWithCount()` utility function for retrieving tag data
- Adds Tags link to main navigation menu

## Changes
### New Functionality
- Created `/tags` index page with responsive grid layout showing all tags
- Added utility function to count posts per tag (excludes drafts)
- Integrated Tags link into site navigation between Blog and About

### Design & UX
- Follows design inspiration from merox.dev with clean, minimal aesthetic
- Uses existing tag pill styling for consistency
- Displays post counts next to each tag
- Includes breadcrumb navigation
- Responsive grid: 2 columns (mobile) → 3 (tablet) → 4 (desktop)
- Hover effects with color transitions

## Related Issue
Closes #41

## Testing
- ✅ Build succeeds without errors
- ✅ Linting passes
- ✅ Formatting checks pass
- ✅ Tags page generates correctly at `/tags/index.html`
- ✅ All 33 unique tags displayed with accurate counts
- ✅ Navigation includes Tags link
- ✅ Clicking tags navigates to filtered post views

## Screenshots
The tags page displays all blog tags in a clean grid with post counts, making tag discovery easy and intuitive.