### PR TITLE
Enhance Breadcrumbs with Icons (#44)

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,9 +1,11 @@
 ---
 import Link from "@/components/Link.astro";
+import { BookOpen, ChevronRight, FileText, Folder, Home, Package, Tag, User } from "lucide-astro";
 
 interface BreadcrumbItem {
   label: string;
   href?: string;
+  icon?: "home" | "blog" | "blogpost" | "projects" | "project" | "about" | "tags" | "tag";
 }
 
 interface Props {
@@ -12,21 +14,42 @@ interface Props {
 }
 
 const { items, class: className } = Astro.props;
+
+const iconMap = {
+  home: Home,
+  blog: BookOpen,
+  blogpost: FileText,
+  projects: Folder,
+  project: Package,
+  about: User,
+  tags: Tag,
+  tag: Tag,
+};
 ---
 
 <nav class:list={["flex items-center gap-2 text-sm text-muted-foreground", className]}>
   {
-    items.map((item, index) => (
-      <>
-        {item.href ? (
-          <Link href={item.href} class="hover:text-foreground transition-colors">
-            {item.label}
-          </Link>
-        ) : (
-          <span class="text-foreground truncate">{item.label}</span>
-        )}
-        {index < items.length - 1 && <span>/</span>}
-      </>
-    ))
+    items.map((item, index) => {
+      const Icon = item.icon ? iconMap[item.icon] : null;
+      return (
+        <>
+          {item.href ? (
+            <Link
+              href={item.href}
+              class="flex items-center gap-1.5 hover:text-foreground transition-colors"
+            >
+              {Icon && <Icon size={14} />}
+              <span>{item.label}</span>
+            </Link>
+          ) : (
+            <span class="flex items-center gap-1.5 text-foreground truncate">
+              {Icon && <Icon size={14} />}
+              <span class="truncate">{item.label}</span>
+            </span>
+          )}
+          {index < items.length - 1 && <ChevronRight size={14} />}
+        </>
+      );
+    })
   }
 </nav>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,12 @@ import { Github, Linkedin, MapPin } from "lucide-astro";
 >
   <Header slot="header" />
   <main class="w-full mx-auto flex grow flex-col gap-y-12 px-4 max-w-3xl pb-12">
-    <Breadcrumb items={[{ label: "Home", href: "/" }, { label: "About" }]} />
+    <Breadcrumb
+      items={[
+        { label: "Home", href: "/", icon: "home" },
+        { label: "About", icon: "about" },
+      ]}
+    />
 
     <!-- Profile Header -->
     <section class="flex flex-col md:flex-row gap-6 items-center md:items-center">

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -47,7 +47,12 @@ const nextUrl = hasNext ? `/blog/${currentPage + 1}` : null;
 >
   <Header slot="header" />
   <main class="w-full mx-auto flex grow flex-col gap-y-8 px-4 max-w-3xl pb-12">
-    <Breadcrumb items={[{ label: "Home", href: "/" }, { label: "Blog" }]} />
+    <Breadcrumb
+      items={[
+        { label: "Home", href: "/", icon: "home" },
+        { label: "Blog", icon: "blog" },
+      ]}
+    />
 
     <div class="flex flex-col gap-y-2">
       <h1 class="text-3xl font-bold text-foreground">Blog</h1>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -10,7 +10,7 @@ import Layout from "@/layouts/Layout.astro";
 import { getRelatedPosts } from "@/lib/recommendations";
 import { calculateReadingTime, cn, formatBlogDate, formatReadingTime } from "@/lib/utils";
 import { type CollectionEntry, getCollection } from "astro:content";
-import { Calendar, Clock } from "lucide-astro";
+import { BookOpen, Calendar, ChevronRight, Clock, FileText, Home } from "lucide-astro";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog");
@@ -66,11 +66,20 @@ const relatedPosts = await getRelatedPosts(post.slug, 3);
   <section class="grid grid-cols-[minmax(0px,1fr)_min(768px,100%)_minmax(0px,1fr)] gap-y-6 pb-12">
     {/* Breadcrumb */}
     <nav class="col-start-2 flex items-center gap-2 text-sm text-muted-foreground px-4">
-      <Link href="/" class="hover:text-foreground transition-colors">Home</Link>
-      <span>/</span>
-      <Link href="/blog" class="hover:text-foreground transition-colors">Blog</Link>
-      <span>/</span>
-      <span class="text-foreground truncate">{title}</span>
+      <Link href="/" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <Home size={14} />
+        <span>Home</span>
+      </Link>
+      <ChevronRight size={14} />
+      <Link href="/blog" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <BookOpen size={14} />
+        <span>Blog</span>
+      </Link>
+      <ChevronRight size={14} />
+      <span class="flex items-center gap-1.5 text-foreground truncate">
+        <FileText size={14} />
+        <span class="truncate">{title}</span>
+      </span>
     </nav>
 
     {/* Post Header */}

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -47,7 +47,12 @@ const nextUrl = hasNext ? `/projects/${currentPage + 1}` : null;
 >
   <Header slot="header" />
   <main class="w-full mx-auto flex grow flex-col gap-y-8 px-4 max-w-3xl pb-12">
-    <Breadcrumb items={[{ label: "Home", href: "/" }, { label: "Projects" }]} />
+    <Breadcrumb
+      items={[
+        { label: "Home", href: "/", icon: "home" },
+        { label: "Projects", icon: "projects" },
+      ]}
+    />
 
     <div class="flex flex-col gap-y-2">
       <h1 class="text-3xl font-bold text-foreground">Projects</h1>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -6,7 +6,7 @@ import Layout from "@/layouts/Layout.astro";
 import { formatProjectDate } from "@/lib/data-utils";
 import { cn } from "@/lib/utils";
 import { type CollectionEntry, getCollection } from "astro:content";
-import { Calendar, ExternalLink, Github } from "lucide-astro";
+import { Calendar, ChevronRight, ExternalLink, Folder, Github, Home, Package } from "lucide-astro";
 
 export async function getStaticPaths() {
   const projects = await getCollection("projects");
@@ -31,11 +31,23 @@ const formattedDate = formatProjectDate(startDate, endDate);
   <main class="w-full mx-auto flex grow flex-col gap-y-6 px-4 max-w-3xl pb-12">
     <!-- Breadcrumb -->
     <nav class="flex items-center gap-2 text-sm text-muted-foreground">
-      <Link href="/" class="hover:text-foreground transition-colors">Home</Link>
-      <span>/</span>
-      <Link href="/projects" class="hover:text-foreground transition-colors">Projects</Link>
-      <span>/</span>
-      <span class="text-foreground">{title}</span>
+      <Link href="/" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <Home size={14} />
+        <span>Home</span>
+      </Link>
+      <ChevronRight size={14} />
+      <Link
+        href="/projects"
+        class="flex items-center gap-1.5 hover:text-foreground transition-colors"
+      >
+        <Folder size={14} />
+        <span>Projects</span>
+      </Link>
+      <ChevronRight size={14} />
+      <span class="flex items-center gap-1.5 text-foreground truncate">
+        <Package size={14} />
+        <span class="truncate">{title}</span>
+      </span>
     </nav>
 
     <!-- Project Header -->

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -6,7 +6,7 @@ import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
 import { getAllBlogPosts, getAllBlogTags } from "@/lib/data-utils";
 import type { CollectionEntry } from "astro:content";
-import { Tag as TagIcon } from "lucide-astro";
+import { BookOpen, ChevronRight, Home, Tag as TagIcon } from "lucide-astro";
 
 export async function getStaticPaths() {
   const allTags = await getAllBlogTags();
@@ -39,13 +39,25 @@ const postCount = posts.length;
   <main class="w-full mx-auto flex grow flex-col gap-y-8 px-4 max-w-3xl pb-12">
     <!-- Breadcrumb -->
     <nav class="flex items-center gap-2 text-sm text-muted-foreground">
-      <Link href="/" class="hover:text-foreground transition-colors">Home</Link>
-      <span>/</span>
-      <Link href="/blog" class="hover:text-foreground transition-colors">Blog</Link>
-      <span>/</span>
-      <span class="text-foreground">Tags</span>
-      <span>/</span>
-      <span class="text-foreground">{tag}</span>
+      <Link href="/" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <Home size={14} />
+        <span>Home</span>
+      </Link>
+      <ChevronRight size={14} />
+      <Link href="/blog" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <BookOpen size={14} />
+        <span>Blog</span>
+      </Link>
+      <ChevronRight size={14} />
+      <Link href="/tags" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <TagIcon size={14} />
+        <span>Tags</span>
+      </Link>
+      <ChevronRight size={14} />
+      <span class="flex items-center gap-1.5 text-foreground">
+        <TagIcon size={14} />
+        <span>{tag}</span>
+      </span>
     </nav>
 
     <div class="flex flex-col gap-y-3">

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -4,7 +4,7 @@ import Link from "@/components/Link.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
 import { getAllBlogTagsWithCount } from "@/lib/data-utils";
-import { Tag as TagIcon } from "lucide-astro";
+import { BookOpen, ChevronRight, Home, Tag as TagIcon } from "lucide-astro";
 
 const tags = await getAllBlogTagsWithCount();
 ---
@@ -17,11 +17,20 @@ const tags = await getAllBlogTagsWithCount();
   <main class="w-full mx-auto flex grow flex-col gap-y-8 px-4 max-w-3xl pb-12">
     <!-- Breadcrumb -->
     <nav class="flex items-center gap-2 text-sm text-muted-foreground">
-      <Link href="/" class="hover:text-foreground transition-colors">Home</Link>
-      <span>/</span>
-      <Link href="/blog" class="hover:text-foreground transition-colors">Blog</Link>
-      <span>/</span>
-      <span class="text-foreground">Tags</span>
+      <Link href="/" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <Home size={14} />
+        <span>Home</span>
+      </Link>
+      <ChevronRight size={14} />
+      <Link href="/blog" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <BookOpen size={14} />
+        <span>Blog</span>
+      </Link>
+      <ChevronRight size={14} />
+      <span class="flex items-center gap-1.5 text-foreground">
+        <TagIcon size={14} />
+        <span>Tags</span>
+      </span>
     </nav>
 
     <!-- Header -->


### PR DESCRIPTION
## Summary
- Enhances breadcrumb navigation with Lucide icons for better visual hierarchy
- Replaces forward slash separators with ChevronRight icons
- Implements consistent icon usage across all pages

## Changes
### Breadcrumb Component Enhancement
- Updated `Breadcrumb.astro` to support optional icons via icon prop
- Added icon mapping for: home, blog, blogpost, projects, project, about, tags, tag
- Replaced `/` separators with `ChevronRight` icons
- Icons displayed at 14px size with proper spacing

### Updated Pages
#### Listing Pages (using Breadcrumb component)
- About page: Home > About (with User icon)
- Blog listing: Home > Blog (with BookOpen icon)
- Projects listing: Home > Projects (with Folder icon)

#### Detail Pages (inline breadcrumbs)
- Blog posts: Home > Blog > Post Title (with FileText icon)
- Project details: Home > Projects > Project Title (with Package icon)

#### Tags Pages
- Tags index: Home > Blog > Tags (with Tag icon)
- Individual tags: Home > Blog > Tags > Tag Name (with Tag icons)

### Design
- Icon size: 14px (consistent with issue specification)
- Separators: ChevronRight instead of `/`
- Colors: text-muted-foreground with hover:text-foreground transitions
- Spacing: gap-1.5 between icon and text, gap-2 between items
- Follows design inspiration from merox.dev and astro-erudite

## Related Issue
Closes #44

## Testing
- ✅ Build succeeds without errors
- ✅ Linting passes
- ✅ Formatting checks pass
- ✅ Icons display correctly on all pages
- ✅ ChevronRight separators render properly
- ✅ Hover effects work as expected
- ✅ Mobile responsive (text truncates when needed)
- ✅ Consistent visual style across all pages

## Visual Improvements
The enhanced breadcrumbs provide better visual hierarchy and match the modern aesthetic of similar portfolios, making navigation more intuitive and visually appealing.