### PR TITLE
Fix tags breadcrumb structure (#65)

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -6,7 +6,7 @@ import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
 import { getAllBlogPosts, getAllBlogTags } from "@/lib/data-utils";
 import type { CollectionEntry } from "astro:content";
-import { BookOpen, ChevronRight, Home, Tag as TagIcon } from "lucide-astro";
+import { ChevronRight, Home, Tag as TagIcon } from "lucide-astro";
 
 export async function getStaticPaths() {
   const allTags = await getAllBlogTags();
@@ -42,11 +42,6 @@ const postCount = posts.length;
       <Link href="/" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
         <Home size={14} />
         <span>Home</span>
-      </Link>
-      <ChevronRight size={14} />
-      <Link href="/blog" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
-        <BookOpen size={14} />
-        <span>Blog</span>
       </Link>
       <ChevronRight size={14} />
       <Link href="/tags" class="flex items-center gap-1.5 hover:text-foreground transition-colors">

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -4,7 +4,7 @@ import Link from "@/components/Link.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
 import { getAllBlogTagsWithCount } from "@/lib/data-utils";
-import { BookOpen, ChevronRight, Home, Tag as TagIcon } from "lucide-astro";
+import { ChevronRight, Home, Tag as TagIcon } from "lucide-astro";
 
 const tags = await getAllBlogTagsWithCount();
 ---
@@ -20,11 +20,6 @@ const tags = await getAllBlogTagsWithCount();
       <Link href="/" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
         <Home size={14} />
         <span>Home</span>
-      </Link>
-      <ChevronRight size={14} />
-      <Link href="/blog" class="flex items-center gap-1.5 hover:text-foreground transition-colors">
-        <BookOpen size={14} />
-        <span>Blog</span>
       </Link>
       <ChevronRight size={14} />
       <span class="flex items-center gap-1.5 text-foreground">


### PR DESCRIPTION
## Summary
- Fixed tags breadcrumb to correctly show tags as a top-level section
- Removed incorrect Blog link from breadcrumb hierarchy

## Changes
- **Tags index page**: Changed from "Home > Blog > Tags" to "Home > Tags"
- **Individual tag pages**: Changed from "Home > Blog > Tags > [tag]" to "Home > Tags > [tag]"
- Removed unused `BookOpen` icon imports from both files

## Related
Closes #65

## Testing
- ✅ Lint passed
- ✅ Format check passed
- ✅ Build successful