### PR TITLE
Remove Tags from navigation (#67)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -21,7 +21,6 @@ export const SITE = {
 export const NAV_LINKS = [
   { href: "/projects", label: "Projects" },
   { href: "/blog", label: "Blog" },
-  { href: "/tags", label: "Tags" },
   { href: "/about", label: "About" },
 ] as const;
 

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -82,8 +82,16 @@ const postCount = posts.length;
       )
     }
 
-    <!-- Back to Blog -->
-    <div class="pt-6 border-t border-border">
+    <!-- Navigation Links -->
+    <div class="flex items-center gap-4 pt-6 border-t border-border">
+      <Link
+        href="/tags"
+        class="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <TagIcon size={16} />
+        View all tags
+      </Link>
+      <span class="text-muted-foreground">•</span>
       <Link
         href="/blog"
         class="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary
- Removed Tags from header and footer navigation
- Made tags an easter egg discovery feature
- Added "View all tags" link on individual tag pages for discoverability

## Changes
- **Navigation**: Removed `/tags` link from `NAV_LINKS` in `src/consts.ts`
- **Footer**: Automatically updated (uses `NAV_LINKS`)
- **Tag pages**: Added "View all tags" link alongside "Back to Blog" for easy navigation between tags

## Discovery Methods
Users can now discover tags through:
1. Clicking tags in blog post cards
2. Clicking tags in individual blog posts
3. "View all tags" link on individual tag pages
4. Direct URL entry (/tags)

## Related
Closes #67

## Testing
- ✅ Lint passed
- ✅ Format check passed
- ✅ Build successful