### PR TITLE
Fix event listener memory leaks in ThemePicker and SearchModal

### DIFF
--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -291,46 +291,95 @@ import { X } from "lucide-astro";
     }, 200);
   }
 
+  // Store event listeners for cleanup
+  let openButtonClickHandler: (() => void) | null = null;
+  let closeButtonDesktopClickHandler: (() => void) | null = null;
+  let modalClickHandler: ((e: Event) => void) | null = null;
+  let escKeyHandler: ((e: KeyboardEvent) => void) | null = null;
+  let cmdKKeyHandler: ((e: KeyboardEvent) => void) | null = null;
+
   function initSearchModal() {
     const openButton = document.getElementById("open-search-modal");
     const closeButtonDesktop = document.getElementById("close-search-modal-desktop");
     const modal = document.getElementById("search-modal");
 
     // Open modal
-    openButton?.addEventListener("click", openSearchModal);
+    openButtonClickHandler = openSearchModal;
+    openButton?.addEventListener("click", openButtonClickHandler);
 
     // Close modal buttons
-    closeButtonDesktop?.addEventListener("click", closeSearchModal);
+    closeButtonDesktopClickHandler = closeSearchModal;
+    closeButtonDesktop?.addEventListener("click", closeButtonDesktopClickHandler);
 
     // Close on backdrop click
-    modal?.addEventListener("click", (e) => {
+    modalClickHandler = (e) => {
       if (e.target === modal) {
         closeSearchModal();
       }
-    });
+    };
+    modal?.addEventListener("click", modalClickHandler);
 
     // Close on ESC key
-    document.addEventListener("keydown", (e) => {
+    escKeyHandler = (e) => {
       if (e.key === "Escape") {
         const modal = document.getElementById("search-modal");
         if (modal && !modal.classList.contains("hidden")) {
           closeSearchModal();
         }
       }
-    });
+    };
+    document.addEventListener("keydown", escKeyHandler);
 
     // Open search modal with Cmd/Ctrl+K
-    document.addEventListener("keydown", (e) => {
+    cmdKKeyHandler = (e) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         openSearchModal();
       }
-    });
+    };
+    document.addEventListener("keydown", cmdKKeyHandler);
+  }
+
+  function cleanupSearchModal() {
+    const openButton = document.getElementById("open-search-modal");
+    const closeButtonDesktop = document.getElementById("close-search-modal-desktop");
+    const modal = document.getElementById("search-modal");
+
+    // Remove open button handler
+    if (openButtonClickHandler && openButton) {
+      openButton.removeEventListener("click", openButtonClickHandler);
+      openButtonClickHandler = null;
+    }
+
+    // Remove close button handler
+    if (closeButtonDesktopClickHandler && closeButtonDesktop) {
+      closeButtonDesktop.removeEventListener("click", closeButtonDesktopClickHandler);
+      closeButtonDesktopClickHandler = null;
+    }
+
+    // Remove modal click handler
+    if (modalClickHandler && modal) {
+      modal.removeEventListener("click", modalClickHandler);
+      modalClickHandler = null;
+    }
+
+    // Remove ESC key handler
+    if (escKeyHandler) {
+      document.removeEventListener("keydown", escKeyHandler);
+      escKeyHandler = null;
+    }
+
+    // Remove Cmd/Ctrl+K handler
+    if (cmdKKeyHandler) {
+      document.removeEventListener("keydown", cmdKKeyHandler);
+      cmdKKeyHandler = null;
+    }
   }
 
   // Initialize on page load
   initSearchModal();
 
-  // Reinitialize on view transitions
+  // Cleanup and reinitialize on view transitions
+  document.addEventListener("astro:before-swap", cleanupSearchModal);
   document.addEventListener("astro:after-swap", initSearchModal);
 </script>

--- a/src/components/ThemePicker.astro
+++ b/src/components/ThemePicker.astro
@@ -116,6 +116,14 @@ import { Monitor, Moon, Sun } from "lucide-astro";
     }
   }
 
+  // Store event listeners for cleanup
+  let buttonClickHandler: ((e: Event) => void) | null = null;
+  const themeButtonHandlers: Map<HTMLButtonElement, () => void> = new Map();
+  let documentClickHandler: ((e: Event) => void) | null = null;
+  let documentKeydownHandler: ((e: KeyboardEvent) => void) | null = null;
+  let mediaQueryChangeHandler: (() => void) | null = null;
+  let mediaQuery: MediaQueryList | null = null;
+
   function initThemePicker() {
     const button = document.getElementById("theme-button");
     const themeButtons = document.querySelectorAll<HTMLButtonElement>("[data-theme-option]");
@@ -125,48 +133,94 @@ import { Monitor, Moon, Sun } from "lucide-astro";
     applyTheme(storedTheme);
 
     // Toggle menu on button click
-    button?.addEventListener("click", (e) => {
+    buttonClickHandler = (e) => {
       e.stopPropagation();
       toggleMenu();
-    });
+    };
+    button?.addEventListener("click", buttonClickHandler);
 
     // Handle theme selection
     themeButtons.forEach((themeButton) => {
-      themeButton.addEventListener("click", () => {
+      const handler = () => {
         const theme = themeButton.dataset.themeOption as Theme;
         applyTheme(theme);
         closeMenu();
-      });
+      };
+      themeButtonHandlers.set(themeButton, handler);
+      themeButton.addEventListener("click", handler);
     });
 
     // Close menu when clicking outside
-    document.addEventListener("click", (e) => {
+    documentClickHandler = (e) => {
       const picker = document.getElementById("theme-picker");
       if (picker && !picker.contains(e.target as Node)) {
         closeMenu();
       }
-    });
+    };
+    document.addEventListener("click", documentClickHandler);
 
     // Close menu on escape key
-    document.addEventListener("keydown", (e) => {
+    documentKeydownHandler = (e) => {
       if (e.key === "Escape") {
         closeMenu();
       }
-    });
+    };
+    document.addEventListener("keydown", documentKeydownHandler);
 
     // Listen for system theme changes when in system mode
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    mediaQuery.addEventListener("change", () => {
+    mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    mediaQueryChangeHandler = () => {
       const currentTheme = localStorage.getItem("theme") as Theme;
       if (currentTheme === "system") {
         applyTheme("system");
       }
+    };
+    mediaQuery.addEventListener("change", mediaQueryChangeHandler);
+  }
+
+  function cleanupThemePicker() {
+    const button = document.getElementById("theme-button");
+    const themeButtons = document.querySelectorAll<HTMLButtonElement>("[data-theme-option]");
+
+    // Remove button click handler
+    if (buttonClickHandler && button) {
+      button.removeEventListener("click", buttonClickHandler);
+      buttonClickHandler = null;
+    }
+
+    // Remove theme button handlers
+    themeButtons.forEach((themeButton) => {
+      const handler = themeButtonHandlers.get(themeButton);
+      if (handler) {
+        themeButton.removeEventListener("click", handler);
+      }
     });
+    themeButtonHandlers.clear();
+
+    // Remove document click handler
+    if (documentClickHandler) {
+      document.removeEventListener("click", documentClickHandler);
+      documentClickHandler = null;
+    }
+
+    // Remove document keydown handler
+    if (documentKeydownHandler) {
+      document.removeEventListener("keydown", documentKeydownHandler);
+      documentKeydownHandler = null;
+    }
+
+    // Remove media query change handler
+    if (mediaQueryChangeHandler && mediaQuery) {
+      mediaQuery.removeEventListener("change", mediaQueryChangeHandler);
+      mediaQueryChangeHandler = null;
+      mediaQuery = null;
+    }
   }
 
   // Initialize on page load
   initThemePicker();
 
-  // Reinitialize on view transitions
+  // Cleanup and reinitialize on view transitions
+  document.addEventListener("astro:before-swap", cleanupThemePicker);
   document.addEventListener("astro:after-swap", initThemePicker);
 </script>


### PR DESCRIPTION
## Summary

- Fixes event listener memory leaks on Astro view transitions (fixes #77)
- Prevents duplicate listeners after navigating between pages

## Changes

### ThemePicker Component
- Store references to all event listeners (click, keydown, media query change)
- Add cleanup function to remove listeners on `astro:before-swap`
- Properly reinitialize listeners on `astro:after-swap`

### SearchModal Component
- Store references to all event listeners (ESC, Cmd/Ctrl+K, click handlers)
- Add cleanup function to remove listeners on `astro:before-swap`
- Properly reinitialize listeners on `astro:after-swap`

## Pattern Used

Follows the same cleanup pattern as `ReadingProgress.astro` which already handles this correctly:
- Store listener references in module-scoped variables
- Create cleanup function to remove all listeners
- Call cleanup on `astro:before-swap` event
- Reinitialize on `astro:after-swap` event

## Related Issues

Closes #77