### PR TITLE
Add Dev Container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+  "name": "Portfolio Dev Environment",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-24-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "astro-build.astro-vscode",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "unifiedjs.vscode-mdx"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "[astro]": {
+          "editor.defaultFormatter": "astro-build.astro-vscode"
+        },
+        "eslint.validate": [
+          "javascript",
+          "javascriptreact",
+          "typescript",
+          "typescriptreact",
+          "astro"
+        ]
+      }
+    }
+  },
+  "forwardPorts": [4321],
+  "portsAttributes": {
+    "4321": {
+      "label": "Astro Dev Server",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "curl -fsSL https://bun.sh/install | bash && export BUN_INSTALL=\"$HOME/.bun\" && export PATH=\"$BUN_INSTALL/bin:$PATH\" && bun install",
+  "remoteUser": "node"
+}


### PR DESCRIPTION
## Summary
Adds Dev Container configuration to provide a consistent development environment across different machines.

## Features
- **Base Image**: Node.js 24 with TypeScript support
- **Package Manager**: Bun installed automatically via post-create command
- **VS Code Extensions**:
  - Astro
  - ESLint
  - Prettier  
  - Tailwind CSS
  - MDX
- **Port Forwarding**: Dev server (4321) with auto-notification
- **Auto-formatting**: Format on save with Prettier
- **GitHub CLI**: Included for PR/issue management

## Benefits
- Consistent development environment for all contributors
- No need to install Node.js, Bun, or dependencies locally
- Works with VS Code, GitHub Codespaces, and other Dev Container-compatible tools
- Faster onboarding for new developers

## Testing
- Configuration follows Dev Container specification
- All required extensions and settings are included

Fixes #60