### PR TITLE
fix(styles): move transition variables to :root for light mode support

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -83,6 +83,12 @@
   /* Borders and ring */
   --border: #dfdad9; /* Highlight Med */
   --ring: #d7827e; /* Rose */
+
+  /* Transition durations */
+  --transition-fast: 150ms;
+  --transition-normal: 200ms;
+  --transition-slow: 300ms;
+  --ease-default: ease-out;
 }
 
 /* ==========================================================================
@@ -118,12 +124,6 @@
   /* Borders and ring */
   --border: #403d52; /* Highlight Med */
   --ring: #ebbcba; /* Rose */
-
-  /* Transition durations */
-  --transition-fast: 150ms;
-  --transition-normal: 200ms;
-  --transition-slow: 300ms;
-  --ease-default: ease-out;
 }
 
 /* Smooth theme transitions */


### PR DESCRIPTION
## Summary
Fixes #120

Transition duration CSS variables were only defined in `[data-theme="dark"]`, causing them to be undefined in light mode. This fix moves these variables to `:root` so they are available in both themes.

## Changes
- Moved `--transition-fast`, `--transition-normal`, `--transition-slow`, and `--ease-default` from `[data-theme="dark"]` block to `:root` block in `src/styles/global.css`

## Impact
- ✅ Transitions now work correctly in light mode
- ✅ Consistent animation behavior across both themes
- ✅ No more undefined CSS variable references
- ✅ Card hover animations work properly in both themes

## Testing
- [x] Build succeeds
- [x] ESLint passes
- [x] Prettier check passes