### PR TITLE
fix(search): close modal when clicking on search result

### DIFF
--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -319,6 +319,15 @@ import { X } from "lucide-astro";
     };
     modal?.addEventListener("click", modalClickHandler);
 
+    // Close on search result click (using event delegation)
+    const resultClickHandler = (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target.closest(".pagefind-ui__result-link")) {
+        closeSearchModal();
+      }
+    };
+    modal?.addEventListener("click", resultClickHandler);
+
     // Close on ESC key
     escKeyHandler = (e) => {
       if (e.key === "Escape") {


### PR DESCRIPTION
## Summary
Fixes #111

Added event delegation to detect clicks on search result links and automatically close the search modal, improving UX by allowing users to immediately see the page they navigated to.

## Changes
- Added click event listener using event delegation in `SearchModal.astro` to detect clicks on `.pagefind-ui__result-link` elements
- Modal now closes automatically when any search result is clicked

## Testing
- [x] Build succeeds
- [x] ESLint passes
- [x] Prettier check passes