### PR TITLE
fix(styles): add missing CSS color variables for light and dark modes

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -61,8 +61,10 @@
   --foreground: #575279; /* Text */
 
   --card: #fffaf3; /* Surface */
+  --card-foreground: #575279; /* Text */
 
   --popover: #f2e9e1; /* Overlay */
+  --popover-foreground: #575279; /* Text */
 
   /* Primary - Rose accent */
   --primary: #d7827e; /* Rose */
@@ -80,8 +82,13 @@
   --accent: #f4ede8; /* Highlight Low */
   --accent-foreground: #575279; /* Text */
 
-  /* Borders and ring */
+  /* Destructive (errors/warnings) */
+  --destructive: #b4637a; /* Love */
+  --destructive-foreground: #faf4ed; /* Base */
+
+  /* Borders and inputs */
   --border: #dfdad9; /* Highlight Med */
+  --input: #dfdad9; /* Highlight Med */
   --ring: #d7827e; /* Rose */
 
   /* Transition durations */
@@ -102,8 +109,10 @@
   --foreground: #e0def4; /* Text */
 
   --card: #1f1d2e; /* Surface */
+  --card-foreground: #e0def4; /* Text */
 
   --popover: #26233a; /* Overlay */
+  --popover-foreground: #e0def4; /* Text */
 
   /* Primary - Rose accent */
   --primary: #ebbcba; /* Rose */
@@ -121,8 +130,13 @@
   --accent: #21202e; /* Highlight Low */
   --accent-foreground: #e0def4; /* Text */
 
-  /* Borders and ring */
+  /* Destructive (errors/warnings) */
+  --destructive: #eb6f92; /* Love */
+  --destructive-foreground: #191724; /* Base */
+
+  /* Borders and inputs */
   --border: #403d52; /* Highlight Med */
+  --input: #403d52; /* Highlight Med */
   --ring: #ebbcba; /* Rose */
 }
 


### PR DESCRIPTION
## Summary
Fixes critical bug where hero and about page content were invisible in light mode due to missing CSS variable definitions.

## Root Cause
The Tailwind theme configuration in `@theme inline` block references these CSS variables:
- `--card-foreground`
- `--popover-foreground`
- `--destructive` and `--destructive-foreground`
- `--input`

However, these variables were not defined in either `:root` (light mode) or `[data-theme="dark"]`, causing the browser to ignore CSS rules that referenced them.

## Changes
Added all missing CSS color variables to both light and dark theme definitions in `src/styles/global.css`:

### Light Mode (`:root`)
- `--card-foreground: #575279`
- `--popover-foreground: #575279`
- `--destructive: #b4637a` (Rose Pine Dawn Love)
- `--destructive-foreground: #faf4ed`
- `--input: #dfdad9`

### Dark Mode (`[data-theme="dark"]`)
- `--card-foreground: #e0def4`
- `--popover-foreground: #e0def4`
- `--destructive: #eb6f92` (Rose Pine Main Love)
- `--destructive-foreground: #191724`
- `--input: #403d52`

## Impact
- ✅ Hero section content now visible in light mode
- ✅ About page content now visible in light mode
- ✅ All text colors working correctly in both themes
- ✅ Consistent color palette using Rose Pine theme

## Testing
- [x] Build succeeds
- [x] ESLint passes
- [x] Prettier check passes
- [x] Content visible in light mode
- [x] Content visible in dark mode