### PR TITLE
feat(tags): show both blog posts and projects on tag pages

### DIFF
--- a/src/lib/data-utils.ts
+++ b/src/lib/data-utils.ts
@@ -8,16 +8,10 @@ type Blog = CollectionEntry<"blog">;
  * Get all projects with optional filtering
  */
 export async function getAllProjects(options?: {
-  featured?: boolean;
   tags?: string[];
   limit?: number;
 }): Promise<Project[]> {
   let projects = await getCollection("projects");
-
-  // Filter by featured status
-  if (options?.featured !== undefined) {
-    projects = projects.filter((project) => project.data.featured === options.featured);
-  }
 
   // Filter by tags
   if (options?.tags && options.tags.length > 0) {
@@ -81,6 +75,38 @@ export async function getAllBlogTagsWithCount(): Promise<Array<{ tag: string; co
 
   publishedPosts.forEach((post) => {
     post.data.tags.forEach((tag) => {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    });
+  });
+
+  return Array.from(tagCounts.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => a.tag.localeCompare(b.tag));
+}
+
+/**
+ * Get all unique tags from projects
+ */
+export async function getAllProjectTags(): Promise<string[]> {
+  const projects = await getCollection("projects");
+  const tags = new Set<string>();
+
+  projects.forEach((project) => {
+    project.data.tags.forEach((tag) => tags.add(tag));
+  });
+
+  return Array.from(tags).sort();
+}
+
+/**
+ * Get all unique tags from projects with counts
+ */
+export async function getAllProjectTagsWithCount(): Promise<Array<{ tag: string; count: number }>> {
+  const projects = await getCollection("projects");
+  const tagCounts = new Map<string, number>();
+
+  projects.forEach((project) => {
+    project.data.tags.forEach((tag) => {
       tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
     });
   });

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,22 +4,39 @@ import BlogCard from "@/components/BlogCard.astro";
 import Breadcrumb from "@/components/Breadcrumb.astro";
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
+import ProjectCard from "@/components/ProjectCard.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
-import { getAllBlogPosts, getAllBlogTags } from "@/lib/data-utils";
+import {
+  getAllBlogPosts,
+  getAllBlogTags,
+  getAllProjects,
+  getAllProjectTags,
+  sortProjects,
+} from "@/lib/data-utils";
 import type { CollectionEntry } from "astro:content";
 import { Tag as TagIcon } from "lucide-astro";
 
 export async function getStaticPaths() {
-  const allTags = await getAllBlogTags();
+  const blogTags = await getAllBlogTags();
+  const projectTags = await getAllProjectTags();
+
+  // Get all unique tags
+  const allTags = Array.from(new Set([...blogTags, ...projectTags])).sort();
+
   const allPosts = await getAllBlogPosts();
+  const allProjects = await getAllProjects();
 
   return allTags.map((tag) => {
     const filteredPosts = allPosts.filter((post) => post.data.tags.includes(tag));
+    const filteredProjects = allProjects.filter((project) => project.data.tags.includes(tag));
+
+    // Sort projects by date
+    const sortedProjects = sortProjects(filteredProjects, "date");
 
     return {
       params: { tag },
-      props: { tag, posts: filteredPosts },
+      props: { tag, posts: filteredPosts, projects: sortedProjects },
     };
   });
 }
@@ -27,15 +44,37 @@ export async function getStaticPaths() {
 interface Props {
   tag: string;
   posts: CollectionEntry<"blog">[];
+  projects: CollectionEntry<"projects">[];
 }
 
-const { tag, posts } = Astro.props;
+const { tag, posts, projects } = Astro.props;
 const postCount = posts.length;
+const projectCount = projects.length;
+const totalCount = postCount + projectCount;
+
+// Combine and sort by date (most recent first)
+type ContentItem = {
+  type: "blog" | "project";
+  date: Date;
+  item: CollectionEntry<"blog"> | CollectionEntry<"projects">;
+};
+const allContent: ContentItem[] = [
+  ...posts.map((post) => ({
+    type: "blog" as const,
+    date: post.data.publishDate,
+    item: post,
+  })),
+  ...projects.map((project) => ({
+    type: "project" as const,
+    date: project.data.startDate,
+    item: project,
+  })),
+].sort((a, b) => b.date.valueOf() - a.date.valueOf());
 ---
 
 <Layout
-  title={`Tag: ${tag} - Blog - ${SITE.title}`}
-  description={`Blog posts tagged with "${tag}"`}
+  title={`Tag: ${tag} - ${SITE.title}`}
+  description={`Content tagged with "${tag}" - ${postCount} ${postCount === 1 ? "post" : "posts"} and ${projectCount} ${projectCount === 1 ? "project" : "projects"}`}
   jsonLd={{ type: "website" }}
 >
   <Header slot="header" />
@@ -57,22 +96,31 @@ const postCount = posts.length;
         <div>
           <h1 class="text-3xl font-bold text-foreground">{tag}</h1>
           <p class="text-sm text-muted-foreground">
-            {postCount}
-            {postCount === 1 ? "post" : "posts"}
+            {totalCount}
+            {totalCount === 1 ? "item" : "items"}
+            {
+              postCount > 0 && projectCount > 0 && (
+                <span>
+                  {" "}
+                  • {postCount} {postCount === 1 ? "post" : "posts"}, {projectCount}{" "}
+                  {projectCount === 1 ? "project" : "projects"}
+                </span>
+              )
+            }
           </p>
         </div>
       </div>
     </div>
 
     {
-      posts.length > 0 ? (
+      allContent.length > 0 ? (
         <div class="flex flex-col gap-6">
-          {posts.map((post) => (
-            <BlogCard post={post} />
-          ))}
+          {allContent.map(({ type, item }) =>
+            type === "blog" ? <BlogCard post={item} /> : <ProjectCard project={item} />
+          )}
         </div>
       ) : (
-        <p class="text-muted-foreground text-center py-8">No posts found with this tag.</p>
+        <p class="text-muted-foreground text-center py-8">No content found with this tag.</p>
       )
     }
 

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -5,15 +5,43 @@ import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
-import { getAllBlogTagsWithCount } from "@/lib/data-utils";
+import { getAllBlogTagsWithCount, getAllProjectTagsWithCount } from "@/lib/data-utils";
 import { Tag as TagIcon } from "lucide-astro";
 
-const tags = await getAllBlogTagsWithCount();
+// Get tags from both blogs and projects
+const blogTags = await getAllBlogTagsWithCount();
+const projectTags = await getAllProjectTagsWithCount();
+
+// Combine tags and their counts
+const tagMap = new Map<string, { blogCount: number; projectCount: number }>();
+
+blogTags.forEach(({ tag, count }) => {
+  tagMap.set(tag, { blogCount: count, projectCount: 0 });
+});
+
+projectTags.forEach(({ tag, count }) => {
+  const existing = tagMap.get(tag);
+  if (existing) {
+    existing.projectCount = count;
+  } else {
+    tagMap.set(tag, { blogCount: 0, projectCount: count });
+  }
+});
+
+// Convert to array and sort alphabetically
+const tags = Array.from(tagMap.entries())
+  .map(([tag, counts]) => ({
+    tag,
+    blogCount: counts.blogCount,
+    projectCount: counts.projectCount,
+    totalCount: counts.blogCount + counts.projectCount,
+  }))
+  .sort((a, b) => a.tag.localeCompare(b.tag));
 ---
 
 <Layout
-  title={`All Tags - Blog - ${SITE.title}`}
-  description="Browse all blog posts by topic. Explore tags and discover content that interests you."
+  title={`All Tags - ${SITE.title}`}
+  description="Browse all blog posts and projects by topic. Explore tags and discover content that interests you."
   jsonLd={{ type: "website" }}
 >
   <Header slot="header" />
@@ -43,13 +71,13 @@ const tags = await getAllBlogTagsWithCount();
     {
       tags.length > 0 ? (
         <div class="flex flex-wrap gap-2">
-          {tags.map(({ tag, count }) => (
+          {tags.map(({ tag, totalCount }) => (
             <Link
               href={`/tags/${tag}`}
               class="inline-flex items-center gap-2 px-3 py-2 bg-muted hover:bg-muted/80 text-foreground rounded-md transition-colors group"
             >
               <span class="text-sm group-hover:text-primary transition-colors">{tag}</span>
-              <span class="text-xs text-muted-foreground">({count})</span>
+              <span class="text-xs text-muted-foreground">({totalCount})</span>
             </Link>
           ))}
         </div>


### PR DESCRIPTION
## Summary
Fixes #110

Tags pages now display both blog posts and projects, not just blog posts. Content is combined and sorted by date with proper type indicators.

## Changes

### Added Project Tag Utilities (`src/lib/data-utils.ts`)
- `getAllProjectTags()` - Get all unique project tags
- `getAllProjectTagsWithCount()` - Get project tags with counts
- Removed unused `featured` filter from `getAllProjects()`

### Updated Tags Index Page (`src/pages/tags/index.astro`)
- Combines tags from both blogs and projects
- Shows total count for each tag across both content types
- Updated title to reflect both content types

### Updated Individual Tag Pages (`src/pages/tags/[tag].astro`)
- Fetches both blog posts and projects for each tag
- Renders both `BlogCard` and `ProjectCard` components
- Sorts all content by date (most recent first)
- Shows count breakdown: "X items • Y posts, Z projects"
- Properly handles tags that exist in only one content type

## Impact
- ✅ Tags page shows combined tags from blogs and projects
- ✅ Individual tag pages display both content types
- ✅ Content sorted chronologically
- ✅ Proper type differentiation with BlogCard vs ProjectCard
- ✅ 101 pages built (previously 68) - includes all project tag pages

## Testing
- [x] Build succeeds
- [x] ESLint passes
- [x] Prettier check passes
- [x] Tag pages generate correctly for all tags