### PR TITLE
fix(tags): improve navigation consistency and context

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -134,7 +134,7 @@ const allContent: ContentItem[] = [
         View all tags
       </Link>
       <span class="text-muted-foreground">•</span>
-      <BackLink href="/blog" label="Back to Blog" />
+      <BackLink href="/" label="Back to Home" />
     </div>
   </main>
 </Layout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -62,7 +62,7 @@ const tags = Array.from(tagMap.entries())
         </div>
         <div>
           <h1 class="text-3xl font-bold text-foreground">All Tags</h1>
-          <p class="text-sm text-muted-foreground">Browse posts by topic</p>
+          <p class="text-sm text-muted-foreground">Browse posts and projects by topic</p>
         </div>
       </div>
     </div>
@@ -86,7 +86,7 @@ const tags = Array.from(tagMap.entries())
       )
     }
 
-    <!-- Back to Blog -->
-    <BackLink href="/blog" label="Back to Blog" />
+    <!-- Back to Home -->
+    <BackLink href="/" label="Back to Home" />
   </main>
 </Layout>


### PR DESCRIPTION
## Summary
- Updates navigation labels on tag pages to reflect that tags now aggregate both blogs and projects (not just blogs)
- Improves contextual accuracy after implementing issue #110

## Changes
- Changed "Back to Blog" → "Back to Home" on `/tags` index page
- Changed "Back to Blog" → "Back to Home" on `/tags/[tag]` pages  
- Updated page description from "Browse posts by topic" → "Browse posts and projects by topic"

## Rationale
After merging #125 (issue #110), tag pages now display both blog posts and projects. The previous "Back to Blog" navigation was misleading since users could have arrived from either the blog or projects page, and the content shown includes both types.

## Related Issues
- Follows up on #110 - Tags now show both blogs and projects
- Improves UX consistency

## Validation
✅ Lint passed
✅ Format check passed
✅ Build successful (101 pages generated)