### PR TITLE
fix(navigation): remove redundant 'Back to Home' buttons on tag pages

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,5 +1,4 @@
 ---
-import BackLink from "@/components/BackLink.astro";
 import BlogCard from "@/components/BlogCard.astro";
 import Breadcrumb from "@/components/Breadcrumb.astro";
 import Header from "@/components/Header.astro";
@@ -124,17 +123,13 @@ const allContent: ContentItem[] = [
       )
     }
 
-    <!-- Navigation Links -->
-    <div class="flex items-center gap-4 pt-6 border-t border-border">
-      <Link
-        href="/tags"
-        class="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <TagIcon size={16} />
-        View all tags
-      </Link>
-      <span class="text-muted-foreground">•</span>
-      <BackLink href="/" label="Back to Home" />
-    </div>
+    <!-- Navigation -->
+    <Link
+      href="/tags"
+      class="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors pt-6 border-t border-border"
+    >
+      <TagIcon size={16} />
+      View all tags
+    </Link>
   </main>
 </Layout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,5 +1,4 @@
 ---
-import BackLink from "@/components/BackLink.astro";
 import Breadcrumb from "@/components/Breadcrumb.astro";
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
@@ -85,8 +84,5 @@ const tags = Array.from(tagMap.entries())
         <p class="text-muted-foreground text-center py-8">No tags found.</p>
       )
     }
-
-    <!-- Back to Home -->
-    <BackLink href="/" label="Back to Home" />
   </main>
 </Layout>


### PR DESCRIPTION
## Summary
- Removes redundant "Back to Home" buttons from tag pages
- Breadcrumbs already provide home navigation, making these buttons unnecessary
- Simplifies navigation and reduces visual clutter

## Changes
- **`/tags` index page**: Removed "Back to Home" button (breadcrumb already shows Home → Tags)
- **`/tags/[tag]` pages**: Removed "Back to Home" button from horizontal navigation
- **`/tags/[tag]` pages**: Kept "View all tags" link for easy navigation between tag pages

## Rationale
Following the principle of avoiding redundant UI elements, the breadcrumb navigation already provides:
- Home navigation (click "Home" in breadcrumb)
- Tags index navigation (click "Tags" in breadcrumb on individual tag pages)

This makes the "Back to Home" buttons redundant. The "View all tags" link is retained as it provides quick access to browse all available tags.

## Navigation After Changes
- `/tags`: Breadcrumb only (Home → Tags)
- `/tags/[tag]`: Breadcrumb + "View all tags" link (Home → Tags → [tag])

## Validation
✅ Lint passed
✅ Format check passed
✅ Build successful (101 pages generated)
✅ Navigation is cleaner and more consistent