### PR TITLE
chore: migrate to GitHub Pages and remove Vercel analytics

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build site
+        run: bun run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import expressiveCode from "astro-expressive-code";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
-  site: "https://abijith.sh",
+  site: "https://abijith-suresh.github.io",
   integrations: [
     expressiveCode({
       themes: ["github-light", "github-dark"],

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@astrojs/mdx": "^4.3.13",
         "@astrojs/rss": "^4.0.15",
         "@astrojs/sitemap": "^3.6.1",
-        "@vercel/analytics": "^1.6.1",
         "astro": "^5.16.6",
         "astro-expressive-code": "^0.41.6",
         "clsx": "^2.1.1",
@@ -398,7 +397,6 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
 
     "@volar/kit": ["@volar/kit@2.4.27", "", { "dependencies": { "@volar/language-service": "2.4.27", "@volar/typescript": "2.4.27", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-ilZoQDMLzqmSsImJRWx4YiZ4FcvvPrPnFVmL6hSsIWB6Bn3qc7k88J9yP32dagrs5Y8EXIlvvD/mAFaiuEOACQ=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@astrojs/mdx": "^4.3.13",
     "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.6.1",
-    "@vercel/analytics": "^1.6.1",
     "astro": "^5.16.6",
     "astro-expressive-code": "^0.41.6",
     "clsx": "^2.1.1",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,8 +4,8 @@ export const SITE = {
   title: "Abijith S",
   description: "Personal portfolio and blog of Abijith S - developer, builder, writer.",
   author: "Abijith S",
-  domain: "abijith.sh",
-  url: "https://abijith.sh",
+  domain: "abijith-suresh.github.io",
+  url: "https://abijith-suresh.github.io",
   locale: "en-US",
 
   // Hero Section

--- a/src/content/blog/testing-mdx-components.mdx
+++ b/src/content/blog/testing-mdx-components.mdx
@@ -66,7 +66,7 @@ function greetUser(user: User): string {
 const user: User = {
   id: "1",
   name: "Abijith",
-  email: "hello@abijith.sh",
+  email: "hello@abijith-suresh.github.io",
 };
 
 console.log(greetUser(user));

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,5 @@
 ---
 import { ViewTransitions } from "astro:transitions";
-import Analytics from "@vercel/analytics/astro";
 import Footer from "@/components/Footer.astro";
 import SearchModal from "@/components/SearchModal.astro";
 import SEO from "@/components/seo/SEO.astro";
@@ -77,7 +76,6 @@ const {
       <Footer />
     </div>
     <SearchModal />
-    <Analytics />
 
     <script is:inline data-astro-rerun>
       (() => {


### PR DESCRIPTION
## Summary
- Renamed repository to abijith-suresh.github.io for GitHub Pages
- Updated site URL from abijith.sh to abijith-suresh.github.io across all config files
- Removed Vercel Analytics component and dependency
- Added GitHub Pages deployment workflow using Bun
- Updated email reference in MDX content to match new domain

## Changes
- **astro.config.mjs**: Updated site URL
- **src/consts.ts**: Updated domain and URL constants
- **src/layouts/Layout.astro**: Removed Vercel Analytics import and component
- **package.json**: Removed @vercel/analytics dependency
- **bun.lock**: Updated lockfile after dependency removal
- **src/content/blog/testing-mdx-components.mdx**: Updated email in example
- **.github/workflows/gh-pages.yml**: Added GitHub Pages deployment workflow

## Deployment
The new workflow will automatically deploy to GitHub Pages when merged to main.