### PR TITLE
refactor: extract duplicate tag calculation logic to shared utility

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,5 +1,7 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 
+import { getAllTagsWithCount } from "@/lib/utils";
+
 type Blog = CollectionEntry<"blog">;
 
 /**
@@ -32,20 +34,11 @@ export async function getAllBlogPosts(options?: {
  */
 export async function getAllBlogTagsWithCount(): Promise<Array<{ tag: string; count: number }>> {
   const posts = await getCollection("blog");
-  const tagCounts = new Map<string, number>();
 
   // Filter out drafts
   const publishedPosts = posts.filter((post) => !post.data.draft);
 
-  publishedPosts.forEach((post) => {
-    post.data.tags.forEach((tag) => {
-      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
-    });
-  });
-
-  return Array.from(tagCounts.entries())
-    .map(([tag, count]) => ({ tag, count }))
-    .sort((a, b) => a.tag.localeCompare(b.tag));
+  return getAllTagsWithCount(publishedPosts, (post) => post.data.tags);
 }
 
 /**

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,5 +1,7 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 
+import { getAllTagsWithCount } from "@/lib/utils";
+
 type Project = CollectionEntry<"projects">;
 
 /**
@@ -65,17 +67,7 @@ export function formatProjectDate(startDate: Date, endDate?: Date): string {
  */
 export async function getAllProjectTagsWithCount(): Promise<Array<{ tag: string; count: number }>> {
   const projects = await getCollection("projects");
-  const tagCounts = new Map<string, number>();
-
-  projects.forEach((project) => {
-    project.data.tags.forEach((tag) => {
-      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
-    });
-  });
-
-  return Array.from(tagCounts.entries())
-    .map(([tag, count]) => ({ tag, count }))
-    .sort((a, b) => a.tag.localeCompare(b.tag));
+  return getAllTagsWithCount(projects, (project) => project.data.tags);
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -78,3 +78,35 @@ export function calculateReadingTime(content: string, wordsPerMinute = 200): num
 export function formatReadingTime(minutes: number): string {
   return `${minutes} min read`;
 }
+
+/**
+ * Calculate tag counts from an array of items
+ *
+ * Generic utility to extract and count tags from any collection of items.
+ * Returns tags sorted alphabetically by name.
+ *
+ * @param items - Array of items to process
+ * @param getTagsFn - Function to extract tags array from each item
+ * @returns Array of objects with tag names and counts, sorted alphabetically
+ *
+ * @example
+ * const posts = [{ tags: ["react", "js"] }, { tags: ["react"] }];
+ * getAllTagsWithCount(posts, (post) => post.tags);
+ * // Returns: [{ tag: "js", count: 1 }, { tag: "react", count: 2 }]
+ */
+export function getAllTagsWithCount<T>(
+  items: T[],
+  getTagsFn: (item: T) => string[]
+): Array<{ tag: string; count: number }> {
+  const tagCounts = new Map<string, number>();
+
+  items.forEach((item) => {
+    getTagsFn(item).forEach((tag) => {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    });
+  });
+
+  return Array.from(tagCounts.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => a.tag.localeCompare(b.tag));
+}


### PR DESCRIPTION
## Summary
- Create generic `getAllTagsWithCount` function in `src/lib/utils.ts`
- Refactor `getAllBlogTagsWithCount` to use shared utility
- Refactor `getAllProjectTagsWithCount` to use shared utility
- Maintain existing functionality with improved code reuse
- Add comprehensive JSDoc documentation with examples

This eliminates duplicate code between blog.ts and projects.ts while maintaining full type safety and existing behavior.

Closes #138