### PR TITLE
fix: update robots.txt sitemap URL to match canonical site URL

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://abijith.sh/sitemap-index.xml
+Sitemap: https://abijith-suresh.github.io/sitemap-index.xml


### PR DESCRIPTION
## Summary

Updates the sitemap URL in `public/robots.txt` from `https://abijith.sh` to `https://abijith-suresh.github.io` to match the canonical site URL used across all other configuration files.

## Problem

The site URL was inconsistent:
- ✅ `astro.config.mjs`: `https://abijith-suresh.github.io`
- ✅ `src/consts.ts`: `https://abijith-suresh.github.io`
- ✅ `AGENTS.md`: `https://abijith-suresh.github.io`
- ❌ `public/robots.txt`: `https://abijith.sh` (incorrect)

This inconsistency could cause SEO issues with search engines not finding the correct sitemap.

## Changes

- Updated `public/robots.txt` to use `https://abijith-suresh.github.io/sitemap-index.xml`

## Note

The custom domain `abijith.sh` is planned for future migration, but the current production URL is the GitHub Pages default.

Fixes #149