### PR TITLE
docs: clean up AGENTS.md structure and remove outdated headings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,9 +238,9 @@ This project uses Husky and lint-staged for automated code quality checks:
 
 **Note:** Vercel deployment was removed in PR #136 (2026-01-25)
 
-## Rules from .github/copilot-instructions.md
+## Development Rules & Best Practices
 
-### Always Do
+### Required Practices
 
 - Run `bun run lint` and `bun run format:check` before commits
 - Use TypeScript strict mode
@@ -248,14 +248,14 @@ This project uses Husky and lint-staged for automated code quality checks:
 - Keep content frontmatter valid against Zod schemas
 - Use `@/*` path alias for all src/ imports
 
-### Ask First
+### Approval Required
 
 - Adding new dependencies
 - Modifying `astro.config.mjs`
 - Changing content collection schemas
 - Modifying the theme/design system
 
-### Never Do
+### Prohibited Actions
 
 - Commit to `dist/`, `.astro/`, or `node_modules/`
 - Use `var` (use `const`/`let`)


### PR DESCRIPTION
## Summary

Fixes #160 - Clean up AGENTS.md structure and remove outdated headings that reference non-existent files.

### Changes Made

- **Removed outdated reference**: Replaced "Rules from .github/copilot-instructions.md" section with "Development Rules & Best Practices"
- **Improved structure**: Better organized with clearer headings:
  - "Required Practices" (formerly "Always Do")
  - "Approval Required" (formerly "Ask First") 
  - "Prohibited Actions" (formerly "Never Do")
- **Verified accuracy**: Confirmed all referenced files and configurations exist and are current
- **No content loss**: All valuable rules and guidelines preserved, just better organized

### Files Modified

- `AGENTS.md` - Restructured section headings and removed outdated file reference

### Verification

- All referenced configuration files (.lintstagedrc.json, .husky/pre-commit, CI workflows) confirmed to exist
- Node.js version requirement (v24+) verified as current
- Pre-commit hooks ran successfully on commit
- No other outdated references found in the document

This makes the documentation more accurate and easier for AI agents to consume by removing references to deleted files and improving the overall structure.