### PR TITLE
feat: audit and update social media links

### DIFF
--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -1,7 +1,7 @@
 ---
 import Link from "@/components/Link.astro";
 import { SOCIAL_LINKS } from "@/consts";
-import { Github, Linkedin, Rss, Twitter } from "lucide-astro";
+import { Cloud, Github, Linkedin, Rss, Twitter } from "lucide-astro";
 
 interface Props {
   class?: string;
@@ -21,6 +21,14 @@ const { class: className, size = 20 } = Astro.props;
     <Github size={size} />
   </Link>
   <Link
+    href={SOCIAL_LINKS.x}
+    external
+    class="text-muted-foreground hover:text-foreground transition-colors"
+    aria-label="X (formerly Twitter)"
+  >
+    <Twitter size={size} />
+  </Link>
+  <Link
     href={SOCIAL_LINKS.linkedin}
     external
     class="text-muted-foreground hover:text-foreground transition-colors"
@@ -29,12 +37,12 @@ const { class: className, size = 20 } = Astro.props;
     <Linkedin size={size} />
   </Link>
   <Link
-    href={SOCIAL_LINKS.twitter}
+    href={SOCIAL_LINKS.bluesky}
     external
     class="text-muted-foreground hover:text-foreground transition-colors"
-    aria-label="Twitter"
+    aria-label="Bluesky"
   >
-    <Twitter size={size} />
+    <Cloud size={size} />
   </Link>
   <Link
     href="/rss.xml"

--- a/src/components/seo/JsonLd.astro
+++ b/src/components/seo/JsonLd.astro
@@ -119,7 +119,12 @@ if (type === "website") {
     url: SITE.url,
     jobTitle: person?.jobTitle || AUTHOR.tagline,
     description: person?.description || AUTHOR.tagline,
-    sameAs: [SOCIAL_LINKS.github, SOCIAL_LINKS.twitter, SOCIAL_LINKS.linkedin].filter(Boolean),
+    sameAs: [
+      SOCIAL_LINKS.github,
+      SOCIAL_LINKS.x,
+      SOCIAL_LINKS.linkedin,
+      SOCIAL_LINKS.bluesky,
+    ].filter(Boolean),
     image: AUTHOR.avatar ? new URL(AUTHOR.avatar, Astro.site).href : undefined,
   };
 }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -31,8 +31,9 @@ export const NAV_LINKS = [
 // Social Links
 export const SOCIAL_LINKS = {
   github: "https://github.com/abijith-suresh",
-  twitter: "https://x.com/abijith_sh",
+  x: "https://x.com/abijith_sh",
   linkedin: "https://linkedin.com/in/abijith-suresh",
+  bluesky: "https://bsky.app/profile/abijith.bsky.social",
 } as const;
 
 // Author Information
@@ -41,7 +42,7 @@ export const AUTHOR = {
   fullName: "Abijith Suresh",
   tagline: "Developer, builder, writer.",
   avatar: "/avatar.jpg",
-  twitterHandle: "@abijith_sh",
+  twitterHandle: "@abijith_sh", // Kept for SEO compatibility (twitter:creator metadata)
 
   // About Page Content
   aboutIntro:

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,9 +2,9 @@
 import Breadcrumb from "@/components/Breadcrumb.astro";
 import Header from "@/components/Header.astro";
 import Link from "@/components/Link.astro";
-import { AUTHOR, SITE, SOCIAL_LINKS } from "@/consts";
+import { AUTHOR, SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
-import { BookOpen, Github, Linkedin } from "lucide-astro";
+import { BookOpen } from "lucide-astro";
 ---
 
 <Layout
@@ -71,27 +71,11 @@ import { BookOpen, Github, Linkedin } from "lucide-astro";
 
         <div class="flex flex-wrap gap-3">
           <Link
-            href={SOCIAL_LINKS.github}
-            external
-            class="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-md hover:bg-muted transition-colors"
-          >
-            <Github size={16} />
-            GitHub
-          </Link>
-          <Link
-            href={SOCIAL_LINKS.linkedin}
-            external
-            class="inline-flex items-center gap-2 px-4 py-2 border border-border rounded-md hover:bg-muted transition-colors"
-          >
-            <Linkedin size={16} />
-            LinkedIn
-          </Link>
-          <Link
             href="/blog"
             class="inline-flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
           >
             <BookOpen size={16} />
-            Read the blog
+            Read my blog
           </Link>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Fixes #151 - Comprehensive audit and update of social media links across the website.

### Changes Made

#### **Social Platform Updates**
- **Added Bluesky**: New social link with Cloud icon placeholder (`https://bsky.app/profile/abijith.bsky.social`)
- **Updated Twitter→X**: Rebranded aria-labels to "X (formerly Twitter)" for clarity
- **Maintained platforms**: GitHub, X, LinkedIn, Bluesky, RSS

#### **Display Location Changes**
- **Footer**: Kept complete social links with proper ordering
- **About page**: Removed individual GitHub/LinkedIn buttons (keeps "Read my blog" CTA)
  - Rationale: Footer always shows social links, avoiding redundancy

#### **Technical Improvements**
- **Icon order**: GitHub → X → LinkedIn → Bluesky → RSS (as requested)
- **Accessibility**: Improved aria-labels with descriptive text
- **SEO**: Updated structured data (JsonLD) to include all social profiles
- **Link behavior**: Maintained new tab opening for all external links

#### **Icon Implementation**
- **Bluesky**: Using Cloud icon from Lucide as placeholder (similar cloud service)
- **Import ordering**: Fixed alphabetically sorted imports per ESLint rules

### Files Modified

- `src/consts.ts` - Added Bluesky link, updated Twitter→X branding
- `src/components/SocialLinks.astro` - Added Bluesky, updated labels, fixed order
- `src/components/seo/JsonLd.astro` - Include Bluesky in structured data
- `src/pages/about.astro` - Removed redundant social links from CTA

### Testing & Validation

- ✅ All links are functional and point to correct profiles
- ✅ Build passes without errors
- ✅ ESLint and Prettier checks pass
- ✅ Pagefind search indexing successful
- ✅ Responsive design maintained
- ✅ Accessibility standards met with proper aria-labels

### Notes

- Used Cloud icon for Bluesky as Lucide doesn't have dedicated Bluesky icon
- Kept `AUTHOR.twitterHandle` for SEO compatibility with `twitter:creator` metadata
- All external links maintain `external` prop for new tab behavior
- RSS feed positioning maintained at far right as originally specified

This improves the social media presence while maintaining clean design and avoiding redundancy between About page and Footer.