### PR TITLE
Add branded empty state for zero search results

### DIFF
--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -208,6 +208,22 @@ import { X } from "lucide-astro";
     padding: 2rem 1rem !important;
     text-align: center !important;
     font-size: 0.875rem !important;
+    line-height: 1.6 !important;
+    white-space: pre-line !important;
+  }
+
+  /* Action links within empty state message */
+  .pagefind-ui__action-link {
+    color: var(--primary) !important;
+    text-decoration: none !important;
+    font-weight: 500 !important;
+    display: inline-block !important;
+    transition: opacity 0.2s ease !important;
+  }
+
+  .pagefind-ui__action-link:hover {
+    opacity: 0.8 !important;
+    text-decoration: underline !important;
   }
 
   /* Hide results count message (e.g., "4 results for typescript") */

--- a/src/lib/search-modal.ts
+++ b/src/lib/search-modal.ts
@@ -126,6 +126,15 @@ export function openModal() {
       showSubResults: false,
       showEmptyFilters: false,
       // No pageSize limit - show all results with scrolling
+      translations: {
+        zero_results: `No results found for "[query]"
+
+Try:
+• Using different keywords
+• Checking your spelling
+• <a href="/blog" class="pagefind-ui__action-link">Browse all blog posts</a>
+• <a href="/projects" class="pagefind-ui__action-link">Browse all projects</a>`,
+      },
     });
 
     // Add content type data attributes and keyboard navigation to results


### PR DESCRIPTION
## Summary
- Adds custom branded empty state message for search results
- Replaces Pagefind's default message with helpful suggestions and action links
- Includes links to browse all blog posts and projects
- Maintains consistent site design and theme support

## Changes
- **src/lib/search-modal.ts**: Added `translations` property to PagefindUI initialization with custom `zero_results` message
- **src/components/SearchModal.astro**: Enhanced CSS styling for empty state message and action links

## Implementation Details
- Uses Pagefind UI's built-in translation system for zero_results state
- Includes helpful suggestions: different keywords, spell checking, browse options
- Action links styled with site theme colors and hover states
- Responsive and accessible design

## Testing
- Build passes successfully
- Linting and formatting checks pass
- Works in both light and dark themes
- Links navigate correctly to blog and project listings

Fixes #142