### PR TITLE
docs: rewrite README to be personal and minimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,183 +1,65 @@
 # Portfolio
 
-> Personal portfolio and blog built with Astro, featuring a clean design and content-first approach.
+> My personal corner of the internet where I share thoughts and experiences in writing, not in short clips or fast feeds.
 
-🌐 **Live Site**: [abijith-suresh.github.io](https://abijith-suresh.github.io)
+[Live Site](https://abijith-suresh.github.io)
 
-## ✨ Features
+## Why This Exists
 
-- 📝 Blog with MDX support and syntax highlighting
-- 🚀 Project showcase with filtering by tags
-- 🔍 Full-text search powered by Pagefind
-- 🌓 Dark/light theme with Rose Pine color scheme
-- 📱 Responsive, mobile-first design
-- ♿ Accessibility-focused with ARIA attributes
-- 🗺️ Auto-generated sitemap and RSS feed
-- ⚡ SPA-like navigation with View Transitions API
+I chose a blog format because I value putting ideas into full sentences. In a world of reels, stories, and rapid scroll, writing lets me slow down and explore things more fully.
 
-## 🛠️ Tech Stack
+I built this site as a home for my thinking. It is where I collect:
 
-- **Framework**: [Astro 5.16+](https://astro.build)
-- **Styling**: [Tailwind CSS 4](https://tailwindcss.com)
-- **Content**: MDX with Expressive Code
-- **Search**: [Pagefind](https://pagefind.app)
-- **Package Manager**: Bun 1.3+ (or npm)
-- **Deployment**: GitHub Pages
+- Reflections from my work and life
+- Things I am learning
+- Notes that help me understand better
+- Occasional technical posts
 
-## 🚀 Getting Started
+I am not on video or social media much. Writing helps me articulate things clearly, and this felt like the right format.
 
-### Prerequisites
+## What You Will Find Here
 
-- Node.js v24+ (ES Module project)
-- Bun 1.3+ (recommended) or npm
+This site is lightly opinionated and intentionally simple. Some content will be polished; other posts may be drafts or personal notes. All of it is here because it helped me think, and I hope it helps readers too.
 
-### Installation
+## Running Locally
 
 ```bash
-# Clone the repository
-git clone https://github.com/abijith-suresh/abijith-suresh.github.io.git
-cd abijith-suresh.github.io
-
-# Install dependencies
 bun install
-
-# Start development server
 bun run dev
 ```
 
-Visit `http://localhost:4321` to see the site.
+Visit `http://localhost:4321`
 
-## 📜 Commands
+## DevContainer Support
 
-| Command                | Description                                       |
-| ---------------------- | ------------------------------------------------- |
-| `bun run dev`          | Start development server                          |
-| `bun run build`        | Build for production (includes Pagefind indexing) |
-| `bun run preview`      | Preview production build locally                  |
-| `bun run lint`         | Run ESLint                                        |
-| `bun run lint:fix`     | Auto-fix ESLint issues                            |
-| `bun run format`       | Format code with Prettier                         |
-| `bun run format:check` | Check formatting without changes                  |
+This project includes a devcontainer configuration for consistent development environments. Works with both Docker and Podman.
 
-### Pre-commit Validation
+**Using Docker:**
 
-**CRITICAL**: Always run before committing:
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop)
+2. Install VSCode [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+3. Open project in VSCode and click "Reopen in Container"
 
-```bash
-bun install && bun run lint && bun run format:check && bun run build
-```
+**Using Podman:**
 
-## 📁 Project Structure
+1. Install [Podman](https://podman.io/getting-started/installation)
+2. Configure VSCode to use Podman: `"dev.containers.dockerPath": "podman"`
+3. Open project in VSCode and click "Reopen in Container"
 
-```
-src/
-├── components/       # Reusable Astro components
-│   ├── mdx/         # MDX components (Callout, CodeBlock)
-│   └── seo/         # SEO components (SEO, JsonLd)
-├── content/          # Content collections (validated by Zod)
-│   ├── blog/        # Blog posts (.md, .mdx)
-│   ├── projects/    # Projects (.md, .mdx)
-│   └── config.ts    # Content schemas
-├── layouts/          # Page layouts
-├── lib/              # Utilities and helpers
-├── pages/            # File-based routing
-│   ├── blog/        # Blog list and post pages
-│   ├── projects/    # Project list and detail pages
-│   ├── tags/        # Tag-based content filtering
-│   ├── about.astro  # About page
-│   ├── index.astro  # Home page
-│   └── rss.xml.js   # RSS feed generation
-├── styles/           # Global CSS
-└── consts.ts         # Site constants
-```
+## Inspiration
 
-## 🎨 Customization
+This site draws inspiration from a few projects whose creators I admire:
 
-### Site Configuration
+- [steipete.me](https://steipete.me) — a clear example of a personal blog focused on substance and openness
+- [astro-erudite](https://astro-erudite.vercel.app/) template
+- [merox-erudite](https://merox-erudite.vercel.app/) template
 
-Edit `src/consts.ts` to customize:
+Their simplicity and thoughtfulness shaped how I approached mine.
 
-- Site metadata (title, description, URL)
-- Social links (GitHub, Twitter, LinkedIn)
-- Posts per page
-- Personal information and about content
+## Technical Details
 
-### Theme Colors
+For development guidelines, project structure, and contribution info, see [AGENTS.md](AGENTS.md).
 
-The site uses the Rose Pine theme. To customize colors, edit `src/styles/global.css`.
+## License
 
-## 📝 Content Management
-
-### Adding a Blog Post
-
-1. Create a new `.md` or `.mdx` file in `src/content/blog/`
-2. Add frontmatter:
-
-```yaml
----
-title: "Your Post Title"
-description: "Brief description"
-publishDate: 2026-01-26
-tags: ["tag1", "tag2"]
-draft: false
----
-```
-
-3. Write your content using Markdown/MDX
-
-### Adding a Project
-
-1. Create a new `.md` file in `src/content/projects/`
-2. Add frontmatter:
-
-```yaml
----
-title: "Project Name"
-description: "Brief description"
-tags: ["React", "TypeScript"]
-github: "https://github.com/..."
-demo: "https://demo.com"
-startDate: 2025-12-01
----
-```
-
-## 🚢 Deployment
-
-The site is configured for deployment on GitHub Pages. Pushes to `main` trigger automatic deployments via GitHub Actions.
-
-### Deployment Workflow
-
-1. Code is pushed to `main` branch
-2. GitHub Actions workflow (`.github/workflows/gh-pages.yml`) triggers
-3. Dependencies are installed and site is built
-4. Build artifacts are deployed to GitHub Pages
-5. Site is live at [abijith-suresh.github.io](https://abijith-suresh.github.io)
-
-## 🧪 Code Quality
-
-This project uses pre-commit hooks to ensure code quality:
-
-- **Husky**: Manages Git hooks
-- **lint-staged**: Runs linters/formatters on staged files
-  - JS/TS/Astro files: ESLint auto-fix + Prettier
-  - JSON/MD/MDX/CSS files: Prettier only
-
-Configuration files:
-
-- `.lintstagedrc.json` - lint-staged rules
-- `.husky/pre-commit` - pre-commit hook
-- `eslint.config.js` - ESLint configuration
-- `.prettierrc` - Prettier configuration
-
-## 📄 License
-
-MIT License - see [LICENSE](LICENSE) for details.
-
-## 👤 Author
-
-**Abijith S**
-
-- Website: [abijith-suresh.github.io](https://abijith-suresh.github.io)
-- GitHub: [@abijith-suresh](https://github.com/abijith-suresh)
-- Twitter: [@abijith_sh](https://twitter.com/abijith_sh)
-- LinkedIn: [abijith-suresh](https://linkedin.com/in/abijith-suresh)
+MIT


### PR DESCRIPTION
## Summary
Rewrites the README to focus on personal story and motivation rather than technical details.

## Problem
The current README (added in PR #157) was too technical and read like generic documentation. It lacked personality and personal context.

## Changes
- **Removed** 152 lines of technical documentation (commands, project structure, deployment details)
- **Added** personal story explaining why the site exists
- **Added** what visitors will find on the site
- **Included** inspiration sources (steipete.me, astro-erudite, merox-erudite)
- **Kept** minimal local setup instructions (bun install && bun run dev)
- **Added** devcontainer quick reference with Docker/Podman options
- **Referenced** AGENTS.md for all technical details

## New Structure
1. **Why This Exists** - Personal motivation and story
2. **What You Will Find Here** - Content overview
3. **Running Locally** - Minimal setup instructions
4. **DevContainer Support** - Quick reference for containerized development
5. **Inspiration** - Credits to projects that influenced this site
6. **Technical Details** - Points to AGENTS.md
7. **License** - MIT

## Testing
- [x] README renders correctly on GitHub
- [x] All links work
- [x] Formatting is clean and readable
- [x] No emojis used (as requested)

## Related Issues
- Closes #161