### PR TITLE
feat(theme): implement Ink & Clay color system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## Unreleased
 
+### Changed
+
+- Implemented the "Ink & Clay" color redesign: replaced the prior teal/Patina accent with a committed fired-clay (terracotta) accent across light and dark themes. The change is implemented in CSS custom properties and applied across components so identity surfaces and interactive states (links, tag pills, nav underlines, reading progress, card hovers, icon buttons, TOC active states, etc.) now use the Clay accent.
+
+- Files updated: src/styles/global.css, src/themes/ink-and-paper.ts, src/pages/api/og.png.ts, src/components/\* (BackLink, ContentCard, Hero, Link, Pagination, ReadingProgress, RecentPosts, SocialLinks, TOCHeader, TOCSidebar, TagList), DESIGN.md, DESIGN.json.
+
+### Docs
+
+- DESIGN.md and DESIGN.json updated to document the new Ink & Clay palette, named tokens, and the design rationale for the committed clay accent.
+
+### Testing
+
+- Verify site build and the following visual checks: homepage and blog pages (light and dark), reading-progress bar, tag pills, TOC active states, header/footer middot, and generated OG image color.
+
 ## 2026-05-01 — Repository metadata cleanup
 
 ### Changed

--- a/DESIGN.json
+++ b/DESIGN.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": 3,
+  "generatedAt": "2026-05-03T00:00:00Z",
+  "title": "Design System: abijith.sh — Ink & Clay",
+  "colorStrategy": "Committed",
+  "colorReference": "Muji production catalog, 1986 — unbleached paper stock, deep red-clay ink stamps, everything functional, nothing decorative.",
+  "extensions": {
+    "colorMeta": {
+      "clay": {
+        "role": "primary-accent",
+        "displayName": "Clay",
+        "description": "Fired terracotta / red ochre pigment. The committed accent color. Covers ~40% of identity surfaces and interactive states.",
+        "lightMode": "oklch(47% 0.115 30)",
+        "darkMode": "oklch(69% 0.115 28)",
+        "tonalRamp": [
+          "oklch(15% 0.08 30)",
+          "oklch(25% 0.10 30)",
+          "oklch(35% 0.11 30)",
+          "oklch(47% 0.115 30)",
+          "oklch(57% 0.115 29)",
+          "oklch(69% 0.115 28)",
+          "oklch(80% 0.09 27)",
+          "oklch(92% 0.04 27)"
+        ],
+        "wcag": {
+          "lightMode": "6.3:1 on oklch(97.5% 0.007 80)",
+          "darkMode": "7.5:1 on oklch(13.5% 0.016 50)"
+        }
+      },
+      "unbleached": {
+        "role": "background-light",
+        "displayName": "Unbleached",
+        "canonical": "oklch(97.5% 0.007 80)",
+        "description": "Light background. Barely-warm off-white, like quality unbleached paper stock."
+      },
+      "inkstone": {
+        "role": "foreground-light",
+        "displayName": "Inkstone",
+        "canonical": "oklch(17% 0.014 50)",
+        "description": "Warm near-black. Clay-tinted printing ink. The darkest light-mode value."
+      },
+      "washi": {
+        "role": "card-light",
+        "displayName": "Washi",
+        "canonical": "oklch(95% 0.010 80)",
+        "description": "Card and secondary surfaces in light mode. One step deeper than Unbleached."
+      },
+      "pith": {
+        "role": "popover-light",
+        "displayName": "Pith",
+        "canonical": "oklch(92% 0.013 78)",
+        "description": "Popover and hover surfaces. Deepest light neutral."
+      },
+      "sandstone": {
+        "role": "muted-text-light",
+        "displayName": "Sandstone",
+        "canonical": "oklch(54% 0.012 65)",
+        "description": "Muted text in light mode. Warm stone gray. Passes WCAG AA (4.7:1 on Unbleached)."
+      },
+      "linen-edge": {
+        "role": "border-light",
+        "displayName": "Linen Edge",
+        "canonical": "oklch(88% 0.015 74)",
+        "description": "Borders and dividers in light mode. Warm, visible, not harsh."
+      },
+      "kiln-red": {
+        "role": "destructive-light",
+        "displayName": "Kiln Red",
+        "canonical": "oklch(45% 0.22 18)",
+        "description": "Destructive / error states in light mode. Pure cardinal red, distinguishable from Clay (H=18 vs H=30)."
+      },
+      "ironwood": {
+        "role": "background-dark",
+        "displayName": "Ironwood",
+        "canonical": "oklch(13.5% 0.016 50)",
+        "description": "Dark background. Warm amber-shifted near-black, like aged ironwood or dark walnut at night."
+      },
+      "warm-offwhite": {
+        "role": "foreground-dark",
+        "displayName": "Warm Off-White",
+        "canonical": "oklch(93% 0.010 75)",
+        "description": "Dark foreground. Off-white with warmth."
+      },
+      "workshop": {
+        "role": "card-dark",
+        "displayName": "Workshop",
+        "canonical": "oklch(18% 0.018 50)",
+        "description": "Card and secondary surfaces in dark mode. Slightly elevated warm surface."
+      },
+      "workbench": {
+        "role": "popover-dark",
+        "displayName": "Workbench",
+        "canonical": "oklch(22% 0.018 50)",
+        "description": "Popover and deeper surfaces in dark mode."
+      },
+      "warm-stone": {
+        "role": "muted-text-dark",
+        "displayName": "Warm Stone",
+        "canonical": "oklch(58% 0.014 62)",
+        "description": "Muted text in dark mode. Warm stone. Passes WCAG AA (4.7:1 on Ironwood)."
+      },
+      "iron-edge": {
+        "role": "border-dark",
+        "displayName": "Iron Edge",
+        "canonical": "oklch(28% 0.020 50)",
+        "description": "Borders in dark mode. Warm, just visible against Ironwood."
+      },
+      "ember-red": {
+        "role": "destructive-dark",
+        "displayName": "Ember Red",
+        "canonical": "oklch(63% 0.22 20)",
+        "description": "Destructive / error states in dark mode."
+      }
+    },
+    "motionTokens": {
+      "fast": "150ms ease-out",
+      "normal": "200ms ease-out",
+      "slow": "300ms ease-out",
+      "pageEnter": "400ms ease-out",
+      "enterDelay1": "60ms",
+      "enterDelay2": "120ms",
+      "enterDelay3": "180ms"
+    },
+    "shadowTokens": {
+      "hoverLift": {
+        "light": "0 4px 12px oklch(0% 0 0 / 0.06)",
+        "dark": "0 4px 12px oklch(0% 0 0 / 0.30)",
+        "transform": "translateY(-2px)",
+        "note": "The only shadow in the system. Applied exclusively on interactive hover feedback."
+      }
+    },
+    "breakpoints": {
+      "sm": "640px",
+      "md": "768px",
+      "lg": "1024px",
+      "xl": "1280px"
+    }
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,221 @@
+---
+name: "abijith.sh"
+description: "Personal portfolio and blog of Abijith S — one backend engineer's home on the web"
+colors:
+  clay: "oklch(47% 0.115 30)"
+  clay-light: "oklch(69% 0.115 28)"
+  unbleached: "oklch(97.5% 0.007 80)"
+  inkstone: "oklch(17% 0.014 50)"
+  washi: "oklch(95% 0.010 80)"
+  pith: "oklch(92% 0.013 78)"
+  sandstone: "oklch(54% 0.012 65)"
+  linen-edge: "oklch(88% 0.015 74)"
+  ironwood: "oklch(13.5% 0.016 50)"
+  warm-offwhite: "oklch(93% 0.010 75)"
+  workshop: "oklch(18% 0.018 50)"
+  workbench: "oklch(22% 0.018 50)"
+  warm-stone: "oklch(58% 0.014 62)"
+  iron-edge: "oklch(28% 0.020 50)"
+  kiln-red: "oklch(45% 0.22 18)"
+  ember-red: "oklch(63% 0.22 20)"
+typography:
+  display:
+    fontFamily: "Satoshi, system-ui, sans-serif"
+    fontSize: "clamp(2.25rem, 6vw, 3.75rem)"
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: "-0.025em"
+  headline:
+    fontFamily: "Satoshi, system-ui, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "normal"
+  title:
+    fontFamily: "Satoshi, system-ui, sans-serif"
+    fontSize: "1.25rem"
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: "normal"
+  body:
+    fontFamily: "Satoshi, system-ui, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.625
+    letterSpacing: "normal"
+  label:
+    fontFamily: "Satoshi, system-ui, sans-serif"
+    fontSize: "0.8125rem"
+    fontWeight: 600
+    lineHeight: 1
+    letterSpacing: "0.05em"
+rounded:
+  sm: "4px"
+  md: "8px"
+  full: "9999px"
+components:
+  content-card:
+    backgroundColor: "washi"
+    textColor: "inkstone"
+    rounded: "md"
+    padding: "20px"
+  content-card-hover:
+    backgroundColor: "pith"
+    borderColor: "clay"
+    rounded: "md"
+  tag-pill:
+    backgroundColor: "clay (10% alpha)"
+    textColor: "clay"
+    rounded: "full"
+    padding: "2px 8px"
+  icon-button:
+    textColor: "clay"
+    rounded: "sm"
+    padding: "8px"
+  nav-link:
+    textColor: "sandstone"
+---
+
+# Design System: abijith.sh
+
+## 1. Overview
+
+**Creative North Star: "The Craftsman's Desk"**
+
+Warm materials, everything in its place, the tools of someone who takes pride in their work. This system draws from the feeling of a well-organized workshop at different hours of the day: unbleached paper under good afternoon light, the same desk by lamplight in the evening. Every surface is intentional. Nothing is ornamental for its own sake.
+
+**Color reference:** _Muji production catalog, 1986 — unbleached paper stock, deep red-clay ink stamps, everything functional, nothing decorative._
+
+The palette breaks from the teal/cream convention that saturated the "warm but technical developer portfolio" aesthetic. Clay — the color of fired terracotta, red ochre pigment, unglazed earthenware — is the committed accent. It is warm-but-not-orange, earthy-but-not-brown. The light theme is unbleached paper under good light; the dark theme is the same workshop after sundown, with the amber warmth of the desk lamp casting everything in the same hue family. Where previous palettes used a cool dark (blue-shifted midnight) against teal, this palette keeps the dark warm so both modes feel like the same room.
+
+**Color strategy: Committed** — Clay carries ~40% of the site's identity surfaces: hero role text, the horizontal rule below the name, prose links, tag pills, active nav states, card hover borders, icon buttons, TOC active headings, and reading progress. The canvas is never Clay. Clay marks identity and interaction. That's its job.
+
+**Key Characteristics:**
+
+- All OKLCH colors. Every neutral is tinted toward warmth (chroma ≥ 0.007); no pure black, no pure white.
+- Committed color strategy: Clay is the system's voice across both themes. The hue is the same; only the lightness changes between light (L=47%) and dark (L=69%).
+- Dark theme is warm-shifted (amber hue 50°), not cool. Both modes feel like the same room.
+- Single typeface (Satoshi) carrying the entire hierarchy through weight and scale.
+- Flat by default. Elevation emerges from tonal layering, not static shadows.
+
+## 2. Colors
+
+### Accent
+
+- **Clay** (`oklch(47% 0.115 30)`): The sole accent. Deep terracotta, red ochre, brick dust. Used for the logo, horizontal rule, prose links, tag pills, active nav, card hover borders, icon buttons, TOC active headings, and reading progress. Passes WCAG AA on the light background (≈6.3:1 contrast). Never used as a background fill or large surface color.
+- **Clay Light** (`oklch(69% 0.115 28)`): Dark theme variant. Same hue family, higher lightness. Passes WCAG AA on the dark background (≈7.5:1). Keeps the same character — fired clay, just caught in warm lamplight.
+
+### Light palette — "Unbleached Paper"
+
+- **Unbleached** (`oklch(97.5% 0.007 80)`): Light background. Barely-warm off-white, like quality unbleached paper stock. Never pure white.
+- **Inkstone** (`oklch(17% 0.014 50)`): Light foreground. Warm near-black, clay-tinted. Like quality printing ink. Warmer and darker than the previous carbon (#2c2c2c).
+- **Washi** (`oklch(95% 0.010 80)`): Card and secondary surfaces. One step deeper than Unbleached.
+- **Pith** (`oklch(92% 0.013 78)`): Popover and hover surfaces. The deepest light neutral.
+- **Sandstone** (`oklch(54% 0.012 65)`): Muted text. Dates, descriptions, metadata. Warm gray. Passes WCAG AA (≈4.7:1).
+- **Linen Edge** (`oklch(88% 0.015 74)`): Borders and dividers. Warm, visible, not harsh.
+- **Kiln Red** (`oklch(45% 0.22 18)`): Destructive / error states. Pure cardinal red — distinguishable from Clay (different hue at 18° vs 30°).
+
+### Dark palette — "Workshop at Night"
+
+- **Ironwood** (`oklch(13.5% 0.016 50)`): Dark background. Warm amber-shifted near-black, like aged ironwood or a very dark walnut. Unlike the previous midnight (#1a1a1d) which was almost-cool.
+- **Warm Off-White** (`oklch(93% 0.010 75)`): Dark foreground. Off-white with warmth.
+- **Workshop** (`oklch(18% 0.018 50)`): Dark card. Slightly elevated warm surface.
+- **Workbench** (`oklch(22% 0.018 50)`): Dark popover. Deeper warm surface.
+- **Warm Stone** (`oklch(58% 0.014 62)`): Dark muted text. Warm stone. Passes WCAG AA (≈4.7:1).
+- **Iron Edge** (`oklch(28% 0.020 50)`): Dark borders. Warm, just visible against the background.
+- **Ember Red** (`oklch(63% 0.22 20)`): Destructive / error states in dark mode.
+
+### Named Rules
+
+**The Committed Strategy Rule.** Clay carries 30–40% of the site's visual weight. It is not a token accent used once in the nav. Every identity surface and interactive state uses Clay. Diluting it defeats the system.
+
+**The Surface Boundary Rule.** Committed ≠ drenched. Page backgrounds and body text are never Clay. Clay marks things you interact with or things that identify the site. The canvas stays warm neutral.
+
+**The No-Neutrals Rule.** Every color in the system has chroma ≥ 0.007. Pure black (#000) and pure white (#fff) are prohibited. Even the darkest dark and brightest light carry a perceptible tint.
+
+**The Same-Room Rule.** Both light and dark themes use the same warm-amber hue direction (H=50–80° in OKLCH). Neither theme is cool. The dark is not the opposite of the light — it's the same desk at a different hour.
+
+## 3. Typography
+
+**Display Font:** Satoshi (system-ui, sans-serif fallback)  
+**Body Font:** Satoshi (same family; weight and scale create hierarchy)  
+**Label Font:** Satoshi (uppercase, wide tracking distinguishes labels from body)
+
+**Character:** Satoshi is a geometric sans with just enough warmth in its terminals to feel human. Single-family: hierarchy lives entirely in weight (400 to 700) and scale (0.8125rem to 3.75rem). No serif/sans personality crutch.
+
+### Hierarchy
+
+- **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero name. Single largest element. Negative tracking keeps it confident.
+- **Headline** (600, 1.5rem, line-height 1.3): Blog post titles, section headings.
+- **Title** (600, 1.25rem, line-height 1.4): Card titles, secondary headings.
+- **Body** (400, 1rem, line-height 1.625): All running content. Max 65–75ch line length.
+- **Label** (600, 0.8125rem, letter-spacing 0.05em, uppercase): Section markers. Used sparingly.
+
+### Named Rules
+
+**The Scale-Only Rule.** One typeface means hierarchy from weight and size contrast alone. Adjacent heading levels must differ by ≥1.25× in size or one full weight step. Flat hierarchies are prohibited.
+
+**The Writing-First Rule.** Blog prose typography takes priority. Body line height (1.625) and line length (65–75ch) are tuned for long-form reading comfort. Everything else accommodates this.
+
+## 4. Elevation
+
+Flat by default. Depth from tonal layering, not shadows. Cards (Washi) sit one step deeper than the page (Unbleached); popovers (Pith) one step deeper still. The eye reads the tonal step as depth without shadow.
+
+Shadows appear exclusively on hover feedback. The card hover state: subtle lift shadow (4px 12px at 6% opacity light / 30% dark) + translateY(-2px). Never applied to non-interactive elements.
+
+### Named Rules
+
+**The Flat-By-Default Rule.** Static shadows prohibited. Elevation through tonal surface steps only. Shadows reserved for interactive hover feedback.
+
+## 5. Components
+
+### Content Card
+
+- **Background:** Washi at rest. Pith on hover. Clay border reveal at hover.
+- **Border:** Linen Edge at 60% opacity at rest, full opacity + Clay on hover.
+- **Shadow:** None at rest. Hover Lift at hover.
+- **Hover behavior:** Background shifts, border solidifies with Clay tint, card lifts 2px, arrow icon shifts to Clay, 200ms ease-out.
+
+### Tag Pill
+
+- **Shape:** Fully rounded.
+- **Background:** Clay at 10% alpha.
+- **Text:** Clay.
+- **No border.** Padding: 2px 8px.
+
+### Navigation Link
+
+- **Text:** Sandstone at rest. Inkstone / Warm Off-White on hover.
+- **Underline:** Invisible at rest. Grows left-to-right (200ms) in Clay on hover.
+
+### Header
+
+- **Logo:** "AS" in Clay, 20px, semibold. The Clay anchor of the page.
+- **Border:** Bottom Linen Edge at 50% opacity.
+
+### Footer
+
+- **Middot** between year and author name: Clay. The only Clay in the footer.
+- **Border:** Top Linen Edge at 50% opacity.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** use Clay on identity markers (logo, accent rules, section bars), interactive states (card hover borders, nav underlines, back links), prose links, tag pills, icon buttons, reading progress, TOC active headings. Clay is the system's voice.
+- **Do** tint every neutral toward warmth (OKLCH hue 50–80°). No surface should feel cold.
+- **Do** make hover states tangible. Cards lift and shadow. Nav links grow underlines. Arrows slide.
+- **Do** cap body text at 65–75ch. Reading comfort is non-negotiable.
+- **Do** use tonal surface steps (Unbleached > Washi > Pith) instead of shadows for depth.
+- **Do** keep both light and dark themes warm. The dark is not the opposite of the light.
+
+### Don't:
+
+- **Don't** use pure black (#000) or pure white (#fff). Every surface and text color is tinted.
+- **Don't** use side-stripe borders (border-left > 1px as accent). Blockquotes use a 2px left border; that's the one exception.
+- **Don't** use gradient text (background-clip: text with a gradient). Emphasis comes from weight or size.
+- **Don't** apply glassmorphism decoratively. All surfaces are opaque and tonal.
+- **Don't** add static shadows to any element. Shadows are for hover feedback only.
+- **Don't** use Clay as a large background fill or body text color. It marks identity and interaction, not surfaces.
+- **Don't** let the dark theme go cool. Ironwood (warm amber-shifted dark) is not negotiable.
+- **Don't** add 3D scenes, particle effects, scroll-jacking, or WebGL showcases. The craft shows in precision, not spectacle.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,44 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Developers, engineers, and technical hiring managers who stumble onto abijith.sh from GitHub, social links, or word of mouth. They arrive curious, scanning quickly for competence signals. Secondary readers: anyone reading blog posts through search or shared links — they come for the content and stay for the voice.
+
+## Product Purpose
+
+A personal corner of the internet. Abijith shares projects, work insights, lessons from books and media, and unpolished thinking. The site is not a resume, not a brand agency, not a startup landing page. It is one backend engineer's home on the web: intentional, opinionated, unmistakably his.
+
+Success looks like a visitor thinking two things in sequence: first, "this person built something impressive for himself," and then, "I want to work with this person or know them better."
+
+## Brand Personality
+
+Confident, precise, personal.
+
+Confident: the site itself is proof of craft. Not loud, not flashy — the kind of confidence that comes from someone who knows what he's doing and doesn't need to announce it.
+
+Precise: clean structure, nothing accidental. Every element earns its place. Reflects a backend engineer's instinct for systems that work without waste.
+
+Personal: this is a real person's space. Warm where it matters, never sterile. The writing voice comes through in the design — thoughtful, slightly informal, genuine.
+
+## Anti-references
+
+- Over-designed developer portfolios with 3D scenes, particle effects, or scroll-jacking animations. Those say "I learned Three.js," not "I built my home."
+- Generic portfolio templates that look like every other developer's site: gradient hero, card grid, identical layout.
+- Notion-style minimalism where everything is so stripped down it could belong to anyone.
+- Sites where the design calls more attention than the person or their writing.
+
+## Design Principles
+
+1. **Craft as proof.** The site itself demonstrates engineering ability. Not through gimmicks, but through precision, performance, and considered details that reveal themselves on closer look.
+2. **Unmistakably personal.** The design should feel like it could only belong to one person. Not a template, not a trend — a deliberate choice that reflects Abijith's taste and temperament.
+3. **Quiet boldness.** Bold does not mean loud. A distinctive color, an unexpected typographic choice, or a confident layout decision can carry more presence than any animation. Stand out through conviction, not decoration.
+4. **Writing first.** The blog is the heartbeat. Typography, spacing, and reading experience take priority over decorative elements. The design serves the words.
+5. **Restraint as a skill.** Every element must justify itself. If something can be removed without losing meaning or personality, remove it. This is a backend engineer's aesthetic: no wasted abstractions, no unused endpoints.
+
+## Accessibility & Inclusion
+
+WCAG AA baseline. Standard compliance: sufficient color contrast, keyboard navigation, screen reader support, reduced motion respect, semantic HTML. Nothing exotic, nothing skipped.

--- a/src/components/BackLink.astro
+++ b/src/components/BackLink.astro
@@ -12,10 +12,7 @@ const { href, label, class: className } = Astro.props;
 ---
 
 <div class:list={cn("pt-6 border-t border-border", className)}>
-  <Link
-    href={href}
-    class="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-  >
+  <Link href={href} class="back-link">
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M10 12L6 8L10 4"

--- a/src/components/ContentCard.astro
+++ b/src/components/ContentCard.astro
@@ -26,7 +26,7 @@ const { title, description, tags, href, meta, class: className } = Astro.props;
         </h3>
         <Icon
           name="fa6-solid:arrow-right"
-          class="w-4 h-4 shrink-0 mt-1 text-muted-foreground/0 group-hover:text-muted-foreground transition-all group-hover:translate-x-0.5"
+          class="w-4 h-4 shrink-0 mt-1 text-muted-foreground/0 transition-all group-hover:translate-x-0.5"
         />
       </div>
       {meta && <p class="text-sm text-muted-foreground">{meta}</p>}

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -13,7 +13,7 @@ import { SITE } from "@/consts";
       </div>
     </div>
 
-    <p class="text-lg md:text-xl text-muted-foreground page-enter page-enter-delay-1">
+    <p class="text-lg md:text-xl page-enter page-enter-delay-1" style="color: var(--color-warm);">
       {SITE.role}
     </p>
 

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -5,11 +5,12 @@ interface Props {
   href: string;
   external?: boolean;
   class?: string;
+  style?: string;
   underline?: boolean;
   prefetch?: boolean | "hover" | "tap" | "load" | "viewport";
 }
 
-const { href, external, class: className, underline, prefetch, ...rest } = Astro.props;
+const { href, external, class: className, style, underline, prefetch, ...rest } = Astro.props;
 const isExternal = external || href.startsWith("http");
 ---
 
@@ -24,7 +25,7 @@ const isExternal = external || href.startsWith("http");
       "underline decoration-muted-foreground underline-offset-[3px] hover:decoration-foreground",
     className
   )}
-  style="transition-duration: var(--transition-slow);"
+  style={`transition-duration: var(--transition-slow);${style ? ` ${style}` : ""}`}
   {...rest}
 >
   <slot />

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -37,7 +37,7 @@ const {
             class:list={cn(
               "inline-flex items-center gap-2 px-4 py-2 rounded-md",
               "text-sm font-medium text-foreground",
-              "border border-border hover:bg-muted/50",
+              "border border-border hover:border-[var(--color-warm)] hover:bg-[var(--color-warm-subtle)]",
               "transition-colors"
             )}
             data-astro-prefetch="viewport"
@@ -61,7 +61,7 @@ const {
             class:list={cn(
               "inline-flex items-center gap-2 px-4 py-2 rounded-md",
               "text-sm font-medium text-foreground",
-              "border border-border hover:bg-muted/50",
+              "border border-border hover:border-[var(--color-warm)] hover:bg-[var(--color-warm-subtle)]",
               "transition-colors"
             )}
             data-astro-prefetch="viewport"

--- a/src/components/ReadingProgress.astro
+++ b/src/components/ReadingProgress.astro
@@ -10,7 +10,7 @@
   <div
     id="reading-progress-bar"
     class="h-full origin-left transition-transform"
-    style="background: var(--color-warm); opacity: 0.5; transform: scaleX(0); transition-duration: var(--transition-fast); transition-timing-function: var(--ease-default);"
+    style="background: var(--color-warm); transform: scaleX(0); transition-duration: var(--transition-fast); transition-timing-function: var(--ease-default);"
   >
   </div>
 </div>

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -22,7 +22,8 @@ const recentPosts = allPosts.slice(0, limit);
         <h2 class="text-lg font-semibold text-foreground">Latest Posts</h2>
         <Link
           href="/blog"
-          class="group inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          class="group inline-flex items-center gap-1.5 text-sm transition-colors"
+          style="color: var(--color-warm);"
           prefetch="viewport"
         >
           View all

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -12,43 +12,19 @@ const { class: className, size = 20 } = Astro.props;
 ---
 
 <div class:list={["flex gap-4", className]}>
-  <Link
-    href={SOCIAL_LINKS.github}
-    external
-    class="text-muted-foreground hover:text-foreground transition-colors"
-    aria-label="GitHub"
-  >
+  <Link href={SOCIAL_LINKS.github} external class="social-link" aria-label="GitHub">
     <Icon name="fa6-brands:github" width={size} height={size} />
   </Link>
-  <Link
-    href={SOCIAL_LINKS.x}
-    external
-    class="text-muted-foreground hover:text-foreground transition-colors"
-    aria-label="X (formerly Twitter)"
-  >
+  <Link href={SOCIAL_LINKS.x} external class="social-link" aria-label="X (formerly Twitter)">
     <Icon name="fa6-brands:x-twitter" width={size} height={size} />
   </Link>
-  <Link
-    href={SOCIAL_LINKS.linkedin}
-    external
-    class="text-muted-foreground hover:text-foreground transition-colors"
-    aria-label="LinkedIn"
-  >
+  <Link href={SOCIAL_LINKS.linkedin} external class="social-link" aria-label="LinkedIn">
     <Icon name="fa6-brands:linkedin" width={size} height={size} />
   </Link>
-  <Link
-    href={SOCIAL_LINKS.bluesky}
-    external
-    class="text-muted-foreground hover:text-foreground transition-colors"
-    aria-label="Bluesky"
-  >
+  <Link href={SOCIAL_LINKS.bluesky} external class="social-link" aria-label="Bluesky">
     <Icon name="fa6-brands:bluesky" width={size} height={size} />
   </Link>
-  <Link
-    href="/rss.xml"
-    class="text-muted-foreground hover:text-foreground transition-colors"
-    aria-label="RSS Feed"
-  >
+  <Link href="/rss.xml" class="social-link" aria-label="RSS Feed">
     <Icon name="fa6-solid:rss" width={size} height={size} />
   </Link>
 </div>

--- a/src/components/TOCHeader.astro
+++ b/src/components/TOCHeader.astro
@@ -37,12 +37,11 @@ function getIndent(depth: number): string {
                 />
                 <circle
                   id="mobile-toc-progress-circle"
-                  class="text-primary"
                   cx="12"
                   cy="12"
                   r="10"
                   fill="none"
-                  stroke="currentColor"
+                  stroke="var(--color-warm)"
                   stroke-width="2"
                   stroke-dasharray="62.83"
                   stroke-dashoffset="62.83"

--- a/src/components/TOCSidebar.astro
+++ b/src/components/TOCSidebar.astro
@@ -32,7 +32,7 @@ function getIndent(depth: number): string {
             <li class:list={["text-sm text-foreground/60", getIndent(heading.depth)]}>
               <a
                 href={`#${heading.slug}`}
-                class="toc-sidebar-link underline decoration-transparent underline-offset-[3px] transition-all duration-200 hover:decoration-inherit hover:text-foreground"
+                class="toc-sidebar-link underline decoration-transparent underline-offset-[3px] transition-all duration-200"
                 data-heading-link={heading.slug}
               >
                 {heading.text}
@@ -53,7 +53,7 @@ function getIndent(depth: number): string {
     headerOffset: 100,
     containerSelector: "#toc-sidebar-container",
     linkSelector: "[data-heading-link]",
-    activeClass: "text-foreground",
+    activeClass: "active",
     enableSmoothScroll: true,
   });
 

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -18,11 +18,8 @@ const { tags, class: className, linkClass } = Astro.props;
       {tags.map((tag) => (
         <Link
           href={getTagHref(tag)}
-          class:list={cn(
-            "text-xs px-3 py-1.5 bg-muted text-muted-foreground rounded-md font-medium",
-            "hover:bg-muted/80 transition-colors",
-            linkClass
-          )}
+          class:list={cn("text-xs px-3 py-1.5 rounded-md font-medium transition-colors", linkClass)}
+          style="background: var(--color-warm-muted); color: var(--color-warm);"
           prefetch="viewport"
         >
           {tag}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -16,7 +16,7 @@ import { Icon } from "astro-icon/components";
     <div class="flex flex-col items-center justify-center gap-y-6 py-20 page-enter">
       <div
         class="text-8xl font-bold select-none"
-        style="color: var(--color-warm); opacity: 0.3;"
+        style="color: var(--color-warm); opacity: 0.5;"
         aria-hidden="true"
       >
         404

--- a/src/pages/api/og.png.ts
+++ b/src/pages/api/og.png.ts
@@ -9,12 +9,12 @@ export const GET: APIRoute = async ({ url }) => {
   const description = url.searchParams.get("description") || SITE.description;
   const type = url.searchParams.get("type") || "website";
 
-  // Ink & Paper theme colors
+  // Ink & Clay theme colors
   const theme = {
-    background: "#faf8f5", // Light mode background
-    foreground: "#2c2c2c", // Dark text
-    accent: "#4a8f8c", // Teal accent
-    muted: "#8a8580", // Muted text
+    background: "#faf8f5", // Light mode background (warm off-white)
+    foreground: "#1e1610", // Warm near-black text
+    accent: "#8f4028", // Clay accent
+    muted: "#7a6e68", // Warm stone gray
   };
 
   // Generate HTML for the OG image

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,36 +38,39 @@
 }
 
 :root {
-  --background: #faf8f5;
-  --foreground: #2c2c2c;
+  /* ── Light theme: Unbleached Paper ─────────────────────────────────────── */
+  --background: oklch(97.5% 0.007 80); /* barely-warm off-white, paper stock */
+  --foreground: oklch(17% 0.014 50); /* warm near-black, clay-tinted ink    */
 
-  --card: #f3f0eb;
-  --card-foreground: #2c2c2c;
+  --card: oklch(95% 0.01 80); /* one step deeper than background     */
+  --card-foreground: oklch(17% 0.014 50);
 
-  --popover: #ede9e3;
-  --popover-foreground: #2c2c2c;
+  --popover: oklch(92% 0.013 78); /* hover / popover surface             */
+  --popover-foreground: oklch(17% 0.014 50);
 
-  --primary: #2c2c2c;
-  --primary-foreground: #faf8f5;
+  --primary: oklch(17% 0.014 50);
+  --primary-foreground: oklch(97.5% 0.007 80);
 
-  --secondary: #f3f0eb;
-  --secondary-foreground: #2c2c2c;
+  --secondary: oklch(95% 0.01 80);
+  --secondary-foreground: oklch(17% 0.014 50);
 
-  --muted: #f3f0eb;
-  --muted-foreground: #8a8580;
+  --muted: oklch(95% 0.01 80);
+  --muted-foreground: oklch(54% 0.012 65); /* warm stone gray                    */
 
-  --accent: #ede9e3;
-  --accent-foreground: #2c2c2c;
+  --accent: oklch(92% 0.013 78);
+  --accent-foreground: oklch(17% 0.014 50);
 
-  --destructive: #c4453a;
-  --destructive-foreground: #faf8f5;
+  --destructive: oklch(45% 0.22 18); /* deep cardinal red                   */
+  --destructive-foreground: oklch(97.5% 0.007 80);
 
-  --border: #e4dfd8;
-  --input: #e4dfd8;
-  --ring: #4a8f8c;
+  --border: oklch(88% 0.015 74); /* warm visible border                 */
+  --input: oklch(88% 0.015 74);
+  --ring: oklch(47% 0.115 30); /* clay accent                         */
 
-  --color-warm: #4a8f8c;
-  --color-warm-muted: #4a8f8c18;
+  /* ── Clay accent ─────────────────────────────────────────────────────── */
+  --color-warm: oklch(47% 0.115 30); /* fired clay / red ochre              */
+  --color-warm-muted: oklch(47% 0.115 30 / 0.1);
+  --color-warm-subtle: oklch(47% 0.115 30 / 0.15);
 
   --transition-fast: 150ms;
   --transition-normal: 200ms;
@@ -76,36 +79,39 @@
 }
 
 [data-theme="dark"] {
-  --background: #1a1a1d;
-  --foreground: #e8e4df;
+  /* ── Dark theme: Workshop at Night ─────────────────────────────────────── */
+  --background: oklch(13.5% 0.016 50); /* warm dark — amber-shifted, not cool */
+  --foreground: oklch(93% 0.01 75); /* warm off-white                      */
 
-  --card: #222225;
-  --card-foreground: #e8e4df;
+  --card: oklch(18% 0.018 50); /* slightly elevated warm surface      */
+  --card-foreground: oklch(93% 0.01 75);
 
-  --popover: #2a2a2e;
-  --popover-foreground: #e8e4df;
+  --popover: oklch(22% 0.018 50); /* popover / deeper surface            */
+  --popover-foreground: oklch(93% 0.01 75);
 
-  --primary: #e8e4df;
-  --primary-foreground: #1a1a1d;
+  --primary: oklch(93% 0.01 75);
+  --primary-foreground: oklch(13.5% 0.016 50);
 
-  --secondary: #222225;
-  --secondary-foreground: #e8e4df;
+  --secondary: oklch(18% 0.018 50);
+  --secondary-foreground: oklch(93% 0.01 75);
 
-  --muted: #2a2a2e;
-  --muted-foreground: #8a8580;
+  --muted: oklch(22% 0.018 50);
+  --muted-foreground: oklch(58% 0.014 62); /* warm stone                         */
 
-  --accent: #222225;
-  --accent-foreground: #e8e4df;
+  --accent: oklch(18% 0.018 50);
+  --accent-foreground: oklch(93% 0.01 75);
 
-  --destructive: #e05a4f;
-  --destructive-foreground: #1a1a1d;
+  --destructive: oklch(63% 0.22 20); /* brighter red for dark mode          */
+  --destructive-foreground: oklch(13.5% 0.016 50);
 
-  --border: #363639;
-  --input: #363639;
-  --ring: #6db3b0;
+  --border: oklch(28% 0.02 50); /* warm border                         */
+  --input: oklch(28% 0.02 50);
+  --ring: oklch(69% 0.115 28); /* lighter clay — glows against warm dark */
 
-  --color-warm: #6db3b0;
-  --color-warm-muted: #6db3b018;
+  /* ── Clay accent (dark) ──────────────────────────────────────────────── */
+  --color-warm: oklch(69% 0.115 28); /* fired clay, lighter for dark mode   */
+  --color-warm-muted: oklch(69% 0.115 28 / 0.15);
+  --color-warm-subtle: oklch(69% 0.115 28 / 0.2);
 }
 
 /* Smooth theme transitions */
@@ -165,13 +171,19 @@
 @layer components {
   .card-hover {
     @apply rounded-lg overflow-hidden border border-border/60;
-    @apply hover:border-border hover:bg-accent transition-all;
+    @apply transition-all;
     transition-duration: var(--transition-normal);
   }
 
   .card-hover:hover {
     transform: translateY(-2px);
+    background: var(--color-warm-subtle);
+    border-color: var(--color-warm);
     box-shadow: 0 4px 12px rgb(0 0 0 / 0.06);
+  }
+
+  .group:hover .card-hover svg {
+    color: var(--color-warm);
   }
 
   :where([data-theme="dark"]) .card-hover:hover {
@@ -180,13 +192,50 @@
 
   .tag-pill {
     @apply inline-flex items-center text-xs px-2 py-0.5 rounded-full;
-    @apply bg-muted text-muted-foreground;
+    background: var(--color-warm-muted);
+    color: var(--color-warm);
   }
 
   .icon-button {
     @apply inline-flex items-center justify-center;
-    @apply text-foreground/60 hover:text-foreground;
-    @apply rounded-md transition-colors hover:bg-muted;
+    @apply rounded-md transition-colors;
+    color: var(--color-warm);
+    opacity: 0.6;
+  }
+
+  .icon-button:hover {
+    opacity: 1;
+    background: var(--color-warm-muted);
+  }
+
+  .social-link {
+    @apply text-muted-foreground transition-colors;
+    transition-duration: var(--transition-normal);
+  }
+
+  .social-link:hover {
+    color: var(--color-warm);
+  }
+
+  .toc-sidebar-link:hover {
+    text-decoration: inherit;
+    color: var(--color-warm);
+  }
+
+  .toc-sidebar-link.active {
+    color: var(--color-warm);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+
+  .back-link {
+    @apply inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors;
+    transition-duration: var(--transition-normal);
+  }
+
+  .back-link:hover {
+    color: var(--color-warm);
   }
 
   .nav-link {
@@ -195,7 +244,8 @@
 
   .nav-link::after {
     content: "";
-    @apply absolute -bottom-0.5 left-0 h-px w-0 bg-foreground/40;
+    @apply absolute -bottom-0.5 left-0 h-px w-0;
+    background: var(--color-warm);
     transition: width 0.2s ease-out;
   }
 
@@ -298,7 +348,20 @@
     }
 
     :where(a):not(:where(.not-prose, .not-prose *)) {
-      @apply text-foreground decoration-muted-foreground hover:decoration-foreground font-medium wrap-break-word underline underline-offset-[3px] transition-colors;
+      font-weight: 500;
+      color: var(--color-warm);
+      text-decoration-color: var(--color-warm-muted);
+      text-decoration-line: underline;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
+      transition:
+        color var(--transition-normal),
+        text-decoration-color var(--transition-normal);
+      overflow-wrap: break-word;
+    }
+
+    :where(a:hover):not(:where(.not-prose, .not-prose *)) {
+      text-decoration-color: var(--color-warm);
     }
 
     :where(strong):not(:where(.not-prose, .not-prose *)) {
@@ -327,7 +390,8 @@
     }
 
     :where(blockquote):not(:where(.not-prose, .not-prose *)) {
-      @apply **:text-muted-foreground my-6 border-l-2 pl-6;
+      @apply **:text-muted-foreground my-6 pl-6;
+      border-left: 2px solid var(--color-warm);
     }
 
     :where(hr):not(:where(.not-prose, .not-prose *)) {

--- a/src/themes/ink-and-paper.ts
+++ b/src/themes/ink-and-paper.ts
@@ -2,66 +2,70 @@ import type { ThemeDefinition } from "./types";
 
 const inkAndPaper: ThemeDefinition = {
   name: "ink-and-paper",
-  displayName: "Ink & Paper",
+  displayName: "Ink & Clay",
 
+  // Light theme: Unbleached Paper
+  // Warm off-white canvas, clay-tinted near-black text, warm stone muted.
   light: {
-    background: "#faf8f5",
-    foreground: "#2c2c2c",
+    background: "oklch(97.5% 0.007 80)",
+    foreground: "oklch(17% 0.014 50)",
 
-    card: "#f3f0eb",
-    cardForeground: "#2c2c2c",
+    card: "oklch(95% 0.010 80)",
+    cardForeground: "oklch(17% 0.014 50)",
 
-    popover: "#ede9e3",
-    popoverForeground: "#2c2c2c",
+    popover: "oklch(92% 0.013 78)",
+    popoverForeground: "oklch(17% 0.014 50)",
 
-    primary: "#2c2c2c",
-    primaryForeground: "#faf8f5",
+    primary: "oklch(17% 0.014 50)",
+    primaryForeground: "oklch(97.5% 0.007 80)",
 
-    secondary: "#f3f0eb",
-    secondaryForeground: "#2c2c2c",
+    secondary: "oklch(95% 0.010 80)",
+    secondaryForeground: "oklch(17% 0.014 50)",
 
-    muted: "#f3f0eb",
-    mutedForeground: "#8a8580",
+    muted: "oklch(95% 0.010 80)",
+    mutedForeground: "oklch(54% 0.012 65)",
 
-    accent: "#ede9e3",
-    accentForeground: "#2c2c2c",
+    accent: "oklch(92% 0.013 78)",
+    accentForeground: "oklch(17% 0.014 50)",
 
-    destructive: "#c4453a",
-    destructiveForeground: "#faf8f5",
+    destructive: "oklch(45% 0.22 18)",
+    destructiveForeground: "oklch(97.5% 0.007 80)",
 
-    border: "#e4dfd8",
-    input: "#e4dfd8",
-    ring: "#4a8f8c",
+    border: "oklch(88% 0.015 74)",
+    input: "oklch(88% 0.015 74)",
+    ring: "oklch(47% 0.115 30)",
   },
 
+  // Dark theme: Workshop at Night
+  // Warm amber-shifted dark (not cool midnight), clay accent glows brighter.
   dark: {
-    background: "#1a1a1d",
-    foreground: "#e8e4df",
+    background: "oklch(13.5% 0.016 50)",
+    foreground: "oklch(93% 0.010 75)",
 
-    card: "#222225",
-    cardForeground: "#e8e4df",
+    card: "oklch(18% 0.018 50)",
+    cardForeground: "oklch(93% 0.010 75)",
 
-    popover: "#2a2a2e",
-    popoverForeground: "#e8e4df",
+    popover: "oklch(22% 0.018 50)",
+    popoverForeground: "oklch(93% 0.010 75)",
 
-    primary: "#e8e4df",
-    primaryForeground: "#1a1a1d",
+    primary: "oklch(93% 0.010 75)",
+    primaryForeground: "oklch(13.5% 0.016 50)",
 
-    secondary: "#222225",
-    secondaryForeground: "#e8e4df",
+    secondary: "oklch(18% 0.018 50)",
+    secondaryForeground: "oklch(93% 0.010 75)",
 
-    muted: "#2a2a2e",
-    mutedForeground: "#8a8580",
+    muted: "oklch(22% 0.018 50)",
+    mutedForeground: "oklch(58% 0.014 62)",
 
-    accent: "#222225",
-    accentForeground: "#e8e4df",
+    accent: "oklch(18% 0.018 50)",
+    accentForeground: "oklch(93% 0.010 75)",
 
-    destructive: "#e05a4f",
-    destructiveForeground: "#1a1a1d",
+    destructive: "oklch(63% 0.22 20)",
+    destructiveForeground: "oklch(13.5% 0.016 50)",
 
-    border: "#363639",
-    input: "#363639",
-    ring: "#6db3b0",
+    border: "oklch(28% 0.020 50)",
+    input: "oklch(28% 0.020 50)",
+    ring: "oklch(69% 0.115 28)",
   },
 };
 


### PR DESCRIPTION
## Summary

Implement the Ink & Clay color system: replace the previous teal/patina accent with a fired-clay (terracotta) accent across light/dark themes and update design documentation.

## Changes

- Update CSS theme variables and color tokens (src/styles/global.css, src/themes/ink-and-paper.ts)
- Apply clay accent across components (BackLink, ContentCard, Hero, Link, Pagination, ReadingProgress, RecentPosts, SocialLinks, TOCHeader, TOCSidebar, TagList, 404)
- Update OG image generator to reflect new colors (src/pages/api/og.png.ts)
- Update design documentation (DESIGN.md, DESIGN.json)
- Add PRODUCT.md and update CHANGELOG.md

## Testing
- [ ] Visual check: homepage, blog post pages, dark mode, reading progress, tag pills, TOC active states
- [ ] Verify OG image generation reflects new accent color
- [ ] Quick accessibility contrast checks for links and muted text

## Notes
- This is a presentational update; no behavior/API changes expected. If you want a different hue, we can iterate in a follow-up PR.

## References

- DESIGN.md
