### PR TITLE
feat: improve landing page hero, layout, and UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ### Changed
 
-- Rewrote the hero greeting to a conversational first-person voice ("Hey, I'm Abijith") and rewrote the intro paragraph with more personality and specificity, replacing generic phrases.
+- Rewrote the hero greeting to a conversational first-person voice ("Hey, I'm Abijith"), shortened the intro to two focused sentences with a line break, and changed the tagline from "Software Developer" to "Backend Engineer".
 - Widened the hero clay rule from `w-12` to `w-20` so it reads as a confident compositional element rather than a tick mark.
-- Increased hero spacing (`pt-28/pb-16` → `md:pt-40/md:pb-20`) for a more generous opening; tightened the content sections to `py-8` for a focused rhythm.
+- Adjusted hero spacing to `pt-24 md:pt-32` for generous but not excessive breathing room; tightened content sections to `py-8` for a focused rhythm.
 - Replaced the "Latest Posts" heading with the uppercase tracked label treatment ("RECENT WRITING"), matching the about page's section markers and letting card titles stay the visual focus.
 - Made content card hover arrows visible at ~40% opacity at rest, transitioning to clay color on hover for better clickability affordance.
 - Entrance animations now play only on the first page load per session; subsequent navigations skip the staggered reveal for a snappier experience.
+- Reduced clay accent chroma from 0.115 to 0.065 in both light and dark themes, toning down the intensity while keeping the warm character.
+- Removed card hover background wash and shadow; hover feedback now uses lift + border color change + arrow shift only.
+- Updated DESIGN.md to reflect the new chroma values and simplified hover behavior.
 
 ## 2026-05-01 — Repository metadata cleanup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,18 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ## Unreleased
 
+### Added
+
+- Featured Projects section to the landing page, pulling project cards from the projects collection.
+
 ### Changed
 
-- Implemented the "Ink & Clay" color redesign: replaced the prior teal/Patina accent with a committed fired-clay (terracotta) accent across light and dark themes. The change is implemented in CSS custom properties and applied across components so identity surfaces and interactive states (links, tag pills, nav underlines, reading progress, card hovers, icon buttons, TOC active states, etc.) now use the Clay accent.
-
-- Files updated: src/styles/global.css, src/themes/ink-and-paper.ts, src/pages/api/og.png.ts, src/components/\* (BackLink, ContentCard, Hero, Link, Pagination, ReadingProgress, RecentPosts, SocialLinks, TOCHeader, TOCSidebar, TagList), DESIGN.md, DESIGN.json.
-
-### Docs
-
-- DESIGN.md and DESIGN.json updated to document the new Ink & Clay palette, named tokens, and the design rationale for the committed clay accent.
-
-### Testing
-
-- Verify site build and the following visual checks: homepage and blog pages (light and dark), reading-progress bar, tag pills, TOC active states, header/footer middot, and generated OG image color.
+- Rewrote the hero greeting to a conversational first-person voice ("Hey, I'm Abijith") and rewrote the intro paragraph with more personality and specificity, replacing generic phrases.
+- Widened the hero clay rule from `w-12` to `w-20` so it reads as a confident compositional element rather than a tick mark.
+- Increased hero spacing (`pt-28/pb-16` → `md:pt-40/md:pb-20`) for a more generous opening; tightened the content sections to `py-8` for a focused rhythm.
+- Replaced the "Latest Posts" heading with the uppercase tracked label treatment ("RECENT WRITING"), matching the about page's section markers and letting card titles stay the visual focus.
+- Made content card hover arrows visible at ~40% opacity at rest, transitioning to clay color on hover for better clickability affordance.
+- Entrance animations now play only on the first page load per session; subsequent navigations skip the staggered reveal for a snappier experience.
 
 ## 2026-05-01 — Repository metadata cleanup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 ### Changed
 
 - Rewrote the hero greeting to a conversational first-person voice ("Hey, I'm Abijith"), shortened the intro to two focused sentences with a line break, and changed the tagline from "Software Developer" to "Backend Engineer".
-- Widened the hero clay rule from `w-12` to `w-20` so it reads as a confident compositional element rather than a tick mark.
+- Widened the hero accent rule from `w-12` to `w-20` so it reads as a confident compositional element rather than a tick mark.
 - Adjusted hero spacing to `pt-24 md:pt-32` for generous but not excessive breathing room; tightened content sections to `py-8` for a focused rhythm.
 - Replaced the "Latest Posts" heading with the uppercase tracked label treatment ("RECENT WRITING"), matching the about page's section markers and letting card titles stay the visual focus.
-- Made content card hover arrows visible at ~40% opacity at rest, transitioning to clay color on hover for better clickability affordance.
+- Made content card hover arrows visible at ~40% opacity at rest, transitioning to evergreen on hover for better clickability affordance.
 - Entrance animations now play only on the first page load per session; subsequent navigations skip the staggered reveal for a snappier experience.
 - Replaced clay accent with deep evergreen (OKLCH hue 155, chroma 0.09) for a more grounded, confident identity that works in both light and dark themes.
 - Removed card borders entirely; cards now use tonal surface steps (card → popover) for visual separation.
@@ -26,6 +26,7 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 - Replaced card hover easing from generic `ease-out` to ease-out-quint (`cubic-bezier(0.22, 1, 0.36, 1)`) with 250ms duration for a smoother settle into place.
 - Increased card hover scale from 1.01 to 1.015 for perceptible but subtle movement.
 - Reduced dark theme surface chroma from 0.016–0.020 to 0.006–0.010 (near-neutral with warm bias) to eliminate the reddish-brown cast and let the green accent dominate the canvas.
+- Removed forced transitions from `Link.astro` (it now provides semantics only) and moved `card-hover` from the link to the article wrapper in `ContentCard.astro`, fixing a cascade conflict where Link's `transition-colors` excluded `transform` from the animated properties.
 
 ## 2026-05-01 — Repository metadata cleanup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 - Removed card borders entirely; cards now use tonal surface steps (card → popover) for visual separation.
 - Replaced card translate-y hover with subtle scale(1.01) and tonal background wash for a smoother, more organic feel.
 - Updated DESIGN.md to document the new green accent and simplified card hover behavior.
+- Restored card borders as a static 1px element that does not participate in hover state.
+- Replaced card hover easing from generic `ease-out` to ease-out-quint (`cubic-bezier(0.22, 1, 0.36, 1)`) with 250ms duration for a smoother settle into place.
+- Increased card hover scale from 1.01 to 1.015 for perceptible but subtle movement.
+- Reduced dark theme surface chroma from 0.016–0.020 to 0.006–0.010 (near-neutral with warm bias) to eliminate the reddish-brown cast and let the green accent dominate the canvas.
 
 ## 2026-05-01 — Repository metadata cleanup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 - Replaced the "Latest Posts" heading with the uppercase tracked label treatment ("RECENT WRITING"), matching the about page's section markers and letting card titles stay the visual focus.
 - Made content card hover arrows visible at ~40% opacity at rest, transitioning to clay color on hover for better clickability affordance.
 - Entrance animations now play only on the first page load per session; subsequent navigations skip the staggered reveal for a snappier experience.
-- Reduced clay accent chroma from 0.115 to 0.065 in both light and dark themes, toning down the intensity while keeping the warm character.
-- Removed card hover background wash and shadow; hover feedback now uses lift + border color change + arrow shift only.
-- Updated DESIGN.md to reflect the new chroma values and simplified hover behavior.
+- Replaced clay accent with deep evergreen (OKLCH hue 155, chroma 0.09) for a more grounded, confident identity that works in both light and dark themes.
+- Removed card borders entirely; cards now use tonal surface steps (card → popover) for visual separation.
+- Replaced card translate-y hover with subtle scale(1.01) and tonal background wash for a smoother, more organic feel.
+- Updated DESIGN.md to document the new green accent and simplified card hover behavior.
 
 ## 2026-05-01 — Repository metadata cleanup
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,12 +10,12 @@ colors:
   pith: "oklch(92% 0.013 78)"
   sandstone: "oklch(54% 0.012 65)"
   linen-edge: "oklch(88% 0.015 74)"
-  ironwood: "oklch(13.5% 0.016 50)"
+  ironwood: "oklch(13.5% 0.006 50)"
   warm-offwhite: "oklch(93% 0.010 75)"
-  workshop: "oklch(18% 0.018 50)"
-  workbench: "oklch(22% 0.018 50)"
-  warm-stone: "oklch(58% 0.014 62)"
-  iron-edge: "oklch(28% 0.020 50)"
+  workshop: "oklch(18% 0.008 50)"
+  workbench: "oklch(22% 0.009 50)"
+  warm-stone: "oklch(58% 0.010 55)"
+  iron-edge: "oklch(28% 0.010 50)"
   kiln-red: "oklch(45% 0.22 18)"
   ember-red: "oklch(63% 0.22 20)"
 typography:
@@ -84,7 +84,7 @@ components:
 
 Warm materials, everything in its place, the tools of someone who takes pride in their work. This system draws from the feeling of a well-organized workshop at different hours of the day: unbleached paper under good afternoon light, the same desk by lamplight in the evening. Every surface is intentional. Nothing is ornamental for its own sake.
 
-**Color reference:** _A well-kept workshop at different hours of the day — green-handled precision tools on unbleached paper under good afternoon light, the same bench by lamplight in the evening. Green as the color of systems that work: a successful build, a healthy indicator light, a well-maintained machine. Every surface is intentional. Nothing is ornamental for its own sake._
+**Color reference:** _A well-kept workshop at different hours of the day — green-handled precision tools on unbleached paper under good afternoon light, the same bench by lamplight in the evening. Green as the color of systems that work: a successful build, a healthy indicator light, a well-maintained machine. The dark theme uses near-neutral surfaces with a warm bias, so the green accent becomes the dominant chromatic signal — the only color in the room. Every surface is intentional. Nothing is ornamental for its own sake._
 
 The palette uses warm neutrals paired with a deep evergreen accent. The green breaks from the warm-red/terracotta convention and gives the site a grounded, technical identity. The light theme is unbleached paper under good light; the dark theme is the same workshop after sundown, with the amber warmth of the desk lamp casting everything in the same hue family. Green carries identity and interaction; warm neutrals carry the canvas.
 
@@ -117,12 +117,12 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 
 ### Dark palette — "Workshop at Night"
 
-- **Ironwood** (`oklch(13.5% 0.016 50)`): Dark background. Warm amber-shifted near-black, like aged ironwood or a very dark walnut. Unlike the previous midnight (#1a1a1d) which was almost-cool.
+- **Ironwood** (`oklch(13.5% 0.006 50)`): Dark background. Near-neutral with warm bias at hue 50. Low chroma avoids the reddish-brown cast of higher saturation, letting the green accent carry the room's color.
 - **Warm Off-White** (`oklch(93% 0.010 75)`): Dark foreground. Off-white with warmth.
-- **Workshop** (`oklch(18% 0.018 50)`): Dark card. Slightly elevated warm surface.
-- **Workbench** (`oklch(22% 0.018 50)`): Dark popover. Deeper warm surface.
-- **Warm Stone** (`oklch(58% 0.014 62)`): Dark muted text. Warm stone. Passes WCAG AA (≈4.7:1).
-- **Iron Edge** (`oklch(28% 0.020 50)`): Dark borders. Warm, just visible against the background.
+- **Workshop** (`oklch(18% 0.008 50)`): Dark card. Slightly elevated warm surface.
+- **Workbench** (`oklch(22% 0.009 50)`): Dark popover. Deeper warm surface.
+- **Warm Stone** (`oklch(58% 0.010 55)`): Dark muted text. Warm stone. Passes WCAG AA (≈4.7:1).
+- **Iron Edge** (`oklch(28% 0.010 50)`): Dark borders. Subtle warm trace, just visible against the background.
 - **Ember Red** (`oklch(63% 0.22 20)`): Destructive / error states in dark mode.
 
 ### Named Rules
@@ -159,21 +159,21 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 
 ## 4. Elevation
 
-Flat by default. Depth from tonal layering, not shadows. Cards (Washi) sit one step deeper than the page (Unbleached); popovers (Pith) one step deeper still. The eye reads the tonal step as depth without shadow.
+Flat by default. Depth from tonal layering, not shadows. Cards (Washi) sit one step deeper than the page (Unbleached); popovers (Pith) one step deeper still. The eye reads the tonal step as depth without shadow. Borders (Linen Edge / Iron Edge) provide a clean geometric boundary at rest.
 
-Shadows appear exclusively on hover feedback. The card hover state: subtle lift shadow (4px 12px at 6% opacity light / 30% dark) + translateY(-2px). Never applied to non-interactive elements.
+No shadows on any state. Card hover uses scale and tonal background wash only.
 
 ### Named Rules
 
-**The Flat-By-Default Rule.** Static shadows prohibited. Elevation through tonal surface steps only. Shadows reserved for interactive hover feedback.
+**The Flat-By-Default Rule.** Static shadows prohibited. Elevation through tonal surface steps only. No shadows on hover — card interaction uses scale and tonal background wash only.
 
 ## 5. Components
 
 ### Content Card
 
 - **Background:** Card surface at rest. Popover surface on hover (one tonal step deeper).
-- **Border:** None. Tonal surface difference provides visual separation.
-- **Hover behavior:** Card scales 1.01% with ease-out, background deepens one tonal step, arrow icon shifts to green, 200ms ease-out.
+- **Border:** 1px solid linen edge / iron edge at rest. Does not change on hover.
+- **Hover behavior:** Card scales 1.5% with ease-out-quint (`cubic-bezier(0.22, 1, 0.36, 1)`), background deepens one tonal step, arrow icon shifts to green, 250ms duration.
 
 ### Tag Pill
 
@@ -203,7 +203,7 @@ Shadows appear exclusively on hover feedback. The card hover state: subtle lift 
 
 - **Do** use green on identity markers (logo, accent rules, section bars), interactive states (card hover tonal shift, nav underlines, back links), prose links, tag pills, icon buttons, reading progress, TOC active headings. Green is the system's voice.
 - **Do** tint every neutral toward warmth (OKLCH hue 50–80°). No surface should feel cold.
-- **Do** make hover states tangible. Cards scale and deepen. Nav links grow underlines. Arrows shift.
+- **Do** make hover states tangible. Cards scale and deepen with ease-out-quint easing. Nav links grow underlines. Arrows shift.
 - **Do** cap body text at 65–75ch. Reading comfort is non-negotiable.
 - **Do** use tonal surface steps (Unbleached > Washi > Pith) instead of shadows for depth.
 - **Do** keep both light and dark themes warm. The dark is not the opposite of the light.
@@ -215,7 +215,7 @@ Shadows appear exclusively on hover feedback. The card hover state: subtle lift 
 - **Don't** use side-stripe borders (border-left > 1px as accent). Blockquotes use a 2px left border; that's the one exception.
 - **Don't** use gradient text (background-clip: text with a gradient). Emphasis comes from weight or size.
 - **Don't** apply glassmorphism decoratively. All surfaces are opaque and tonal.
-- **Don't** add static shadows to any element. Shadows are for hover feedback only.
+- **Don't** add static shadows to any element. No shadows on hover either — scale and tonal wash only.
 - **Don't** use Clay as a large background fill or body text color. It marks identity and interaction, not surfaces.
 - **Don't** let the dark theme go cool. Ironwood (warm amber-shifted dark) is not negotiable.
 - **Don't** add 3D scenes, particle effects, scroll-jacking, or WebGL showcases. The craft shows in precision, not spectacle.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,8 +2,8 @@
 name: "abijith.sh"
 description: "Personal portfolio and blog of Abijith S — one backend engineer's home on the web"
 colors:
-  clay: "oklch(47% 0.09 155)"
-  clay-light: "oklch(69% 0.09 155)"
+  evergreen: "oklch(47% 0.09 155)"
+  evergreen-light: "oklch(69% 0.09 155)"
   unbleached: "oklch(97.5% 0.007 80)"
   inkstone: "oklch(17% 0.014 50)"
   washi: "oklch(95% 0.010 80)"
@@ -61,15 +61,14 @@ components:
     padding: "20px"
   content-card-hover:
     backgroundColor: "pith"
-    borderColor: "clay"
     rounded: "md"
   tag-pill:
-    backgroundColor: "clay (10% alpha)"
-    textColor: "clay"
+    backgroundColor: "evergreen (10% alpha)"
+    textColor: "evergreen"
     rounded: "full"
     padding: "2px 8px"
   icon-button:
-    textColor: "clay"
+    textColor: "evergreen"
     rounded: "sm"
     padding: "8px"
   nav-link:
@@ -93,7 +92,7 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 **Key Characteristics:**
 
 - All OKLCH colors. Every neutral is tinted toward warmth (chroma ≥ 0.007); no pure black, no pure white.
-- Committed color strategy: Clay is the system's voice across both themes. The hue is the same; only the lightness changes between light (L=47%) and dark (L=69%).
+- Committed color strategy: Evergreen is the system's voice across both themes. The hue is the same; only the lightness changes between light (L=47%) and dark (L=69%).
 - Dark theme is warm-shifted (amber hue 50°), not cool. Both modes feel like the same room.
 - Single typeface (Satoshi) carrying the entire hierarchy through weight and scale.
 - Flat by default. Elevation emerges from tonal layering, not static shadows.
@@ -108,12 +107,12 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 ### Light palette — "Unbleached Paper"
 
 - **Unbleached** (`oklch(97.5% 0.007 80)`): Light background. Barely-warm off-white, like quality unbleached paper stock. Never pure white.
-- **Inkstone** (`oklch(17% 0.014 50)`): Light foreground. Warm near-black, clay-tinted. Like quality printing ink. Warmer and darker than the previous carbon (#2c2c2c).
+- **Inkstone** (`oklch(17% 0.014 50)`): Light foreground. Warm near-black, green-tinted. Like quality printing ink. Warmer and darker than the previous carbon (#2c2c2c).
 - **Washi** (`oklch(95% 0.010 80)`): Card and secondary surfaces. One step deeper than Unbleached.
 - **Pith** (`oklch(92% 0.013 78)`): Popover and hover surfaces. The deepest light neutral.
 - **Sandstone** (`oklch(54% 0.012 65)`): Muted text. Dates, descriptions, metadata. Warm gray. Passes WCAG AA (≈4.7:1).
 - **Linen Edge** (`oklch(88% 0.015 74)`): Borders and dividers. Warm, visible, not harsh.
-- **Kiln Red** (`oklch(45% 0.22 18)`): Destructive / error states. Pure cardinal red — distinguishable from Clay (different hue at 18° vs 30°).
+- **Kiln Red** (`oklch(45% 0.22 18)`): Destructive / error states. Pure cardinal red — clearly distinguishable from Evergreen (hue 18° vs 155°).
 
 ### Dark palette — "Workshop at Night"
 
@@ -178,14 +177,14 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 ### Tag Pill
 
 - **Shape:** Fully rounded.
-- **Background:** Clay at 10% alpha.
-- **Text:** Clay.
+- **Background:** Evergreen at 10% alpha.
+- **Text:** Evergreen.
 - **No border.** Padding: 2px 8px.
 
 ### Navigation Link
 
 - **Text:** Sandstone at rest. Inkstone / Warm Off-White on hover.
-- **Underline:** Invisible at rest. Grows left-to-right (200ms) in Clay on hover.
+- **Underline:** Invisible at rest. Grows left-to-right (200ms) in Evergreen on hover.
 
 ### Header
 
@@ -211,11 +210,11 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 ### Don't:
 
 - **Don't** use pure black (#000) or pure white (#fff). Every surface and text color is tinted.
-- **Don't** use Clay or terracotta as the accent. The system has moved to a green accent. Update any remaining clay references.
+- **Don't** use terracotta or clay hues as the accent. The system uses an evergreen accent (hue 155°).
 - **Don't** use side-stripe borders (border-left > 1px as accent). Blockquotes use a 2px left border; that's the one exception.
 - **Don't** use gradient text (background-clip: text with a gradient). Emphasis comes from weight or size.
 - **Don't** apply glassmorphism decoratively. All surfaces are opaque and tonal.
 - **Don't** add static shadows to any element. No shadows on hover either — scale and tonal wash only.
-- **Don't** use Clay as a large background fill or body text color. It marks identity and interaction, not surfaces.
+- **Don't** use Evergreen as a large background fill or body text color. It marks identity and interaction, not surfaces.
 - **Don't** let the dark theme go cool. Ironwood (warm amber-shifted dark) is not negotiable.
 - **Don't** add 3D scenes, particle effects, scroll-jacking, or WebGL showcases. The craft shows in precision, not spectacle.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,8 +2,8 @@
 name: "abijith.sh"
 description: "Personal portfolio and blog of Abijith S — one backend engineer's home on the web"
 colors:
-  clay: "oklch(47% 0.115 30)"
-  clay-light: "oklch(69% 0.115 28)"
+  clay: "oklch(47% 0.065 30)"
+  clay-light: "oklch(69% 0.065 28)"
   unbleached: "oklch(97.5% 0.007 80)"
   inkstone: "oklch(17% 0.014 50)"
   washi: "oklch(95% 0.010 80)"
@@ -102,8 +102,8 @@ The palette breaks from the teal/cream convention that saturated the "warm but t
 
 ### Accent
 
-- **Clay** (`oklch(47% 0.115 30)`): The sole accent. Deep terracotta, red ochre, brick dust. Used for the logo, horizontal rule, prose links, tag pills, active nav, card hover borders, icon buttons, TOC active headings, and reading progress. Passes WCAG AA on the light background (≈6.3:1 contrast). Never used as a background fill or large surface color.
-- **Clay Light** (`oklch(69% 0.115 28)`): Dark theme variant. Same hue family, higher lightness. Passes WCAG AA on the dark background (≈7.5:1). Keeps the same character — fired clay, just caught in warm lamplight.
+- **Clay** (`oklch(47% 0.065 30)`): The sole accent. Muted terracotta, warm ochre dust. Used for the logo, horizontal rule, prose links, tag pills, active nav, card hover borders, icon buttons, TOC active headings, and reading progress. Passes WCAG AA on the light background (≈6.3:1 contrast). Never used as a background fill or large surface color.
+- **Clay Light** (`oklch(69% 0.065 28)`): Dark theme variant. Same hue family, higher lightness. Passes WCAG AA on the dark background (≈7.5:1). Keeps the same character — warm clay, just caught in warm lamplight.
 
 ### Light palette — "Unbleached Paper"
 
@@ -173,8 +173,8 @@ Shadows appear exclusively on hover feedback. The card hover state: subtle lift 
 
 - **Background:** Washi at rest. Pith on hover. Clay border reveal at hover.
 - **Border:** Linen Edge at 60% opacity at rest, full opacity + Clay on hover.
-- **Shadow:** None at rest. Hover Lift at hover.
-- **Hover behavior:** Background shifts, border solidifies with Clay tint, card lifts 2px, arrow icon shifts to Clay, 200ms ease-out.
+- **Shadow:** None. Elevation from lift alone.
+- **Hover behavior:** Border solidifies with Clay tint, card lifts 2px, arrow icon shifts to Clay, 200ms ease-out.
 
 ### Tag Pill
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,8 +2,8 @@
 name: "abijith.sh"
 description: "Personal portfolio and blog of Abijith S — one backend engineer's home on the web"
 colors:
-  clay: "oklch(47% 0.065 30)"
-  clay-light: "oklch(69% 0.065 28)"
+  clay: "oklch(47% 0.09 155)"
+  clay-light: "oklch(69% 0.09 155)"
   unbleached: "oklch(97.5% 0.007 80)"
   inkstone: "oklch(17% 0.014 50)"
   washi: "oklch(95% 0.010 80)"
@@ -84,11 +84,11 @@ components:
 
 Warm materials, everything in its place, the tools of someone who takes pride in their work. This system draws from the feeling of a well-organized workshop at different hours of the day: unbleached paper under good afternoon light, the same desk by lamplight in the evening. Every surface is intentional. Nothing is ornamental for its own sake.
 
-**Color reference:** _Muji production catalog, 1986 — unbleached paper stock, deep red-clay ink stamps, everything functional, nothing decorative._
+**Color reference:** _A well-kept workshop at different hours of the day — green-handled precision tools on unbleached paper under good afternoon light, the same bench by lamplight in the evening. Green as the color of systems that work: a successful build, a healthy indicator light, a well-maintained machine. Every surface is intentional. Nothing is ornamental for its own sake._
 
-The palette breaks from the teal/cream convention that saturated the "warm but technical developer portfolio" aesthetic. Clay — the color of fired terracotta, red ochre pigment, unglazed earthenware — is the committed accent. It is warm-but-not-orange, earthy-but-not-brown. The light theme is unbleached paper under good light; the dark theme is the same workshop after sundown, with the amber warmth of the desk lamp casting everything in the same hue family. Where previous palettes used a cool dark (blue-shifted midnight) against teal, this palette keeps the dark warm so both modes feel like the same room.
+The palette uses warm neutrals paired with a deep evergreen accent. The green breaks from the warm-red/terracotta convention and gives the site a grounded, technical identity. The light theme is unbleached paper under good light; the dark theme is the same workshop after sundown, with the amber warmth of the desk lamp casting everything in the same hue family. Green carries identity and interaction; warm neutrals carry the canvas.
 
-**Color strategy: Committed** — Clay carries ~40% of the site's identity surfaces: hero role text, the horizontal rule below the name, prose links, tag pills, active nav states, card hover borders, icon buttons, TOC active headings, and reading progress. The canvas is never Clay. Clay marks identity and interaction. That's its job.
+**Color strategy: Committed** — Green carries ~40% of the site's identity surfaces: hero role text, the horizontal rule below the name, prose links, tag pills, active nav states, icon buttons, TOC active headings, and reading progress. The canvas is never green. Green marks identity and interaction. That's its job.
 
 **Key Characteristics:**
 
@@ -102,8 +102,8 @@ The palette breaks from the teal/cream convention that saturated the "warm but t
 
 ### Accent
 
-- **Clay** (`oklch(47% 0.065 30)`): The sole accent. Muted terracotta, warm ochre dust. Used for the logo, horizontal rule, prose links, tag pills, active nav, card hover borders, icon buttons, TOC active headings, and reading progress. Passes WCAG AA on the light background (≈6.3:1 contrast). Never used as a background fill or large surface color.
-- **Clay Light** (`oklch(69% 0.065 28)`): Dark theme variant. Same hue family, higher lightness. Passes WCAG AA on the dark background (≈7.5:1). Keeps the same character — warm clay, just caught in warm lamplight.
+- **Evergreen** (`oklch(47% 0.09 155)`): The sole accent. Deep forest green, grounded and confident. Used for the logo, horizontal rule, prose links, tag pills, active nav, icon buttons, TOC active headings, and reading progress. Passes WCAG AA on the light background. Never used as a background fill or large surface color.
+- **Evergreen Light** (`oklch(69% 0.09 155)`): Dark theme variant. Same hue family, higher lightness. Passes WCAG AA on the dark background. Keeps the same character — green indicator light caught in warm lamplight.
 
 ### Light palette — "Unbleached Paper"
 
@@ -127,9 +127,9 @@ The palette breaks from the teal/cream convention that saturated the "warm but t
 
 ### Named Rules
 
-**The Committed Strategy Rule.** Clay carries 30–40% of the site's visual weight. It is not a token accent used once in the nav. Every identity surface and interactive state uses Clay. Diluting it defeats the system.
+**The Committed Strategy Rule.** Green carries 30–40% of the site's visual weight. It is not a token accent used once in the nav. Every identity surface and interactive state uses green. Diluting it defeats the system.
 
-**The Surface Boundary Rule.** Committed ≠ drenched. Page backgrounds and body text are never Clay. Clay marks things you interact with or things that identify the site. The canvas stays warm neutral.
+**The Surface Boundary Rule.** Committed ≠ drenched. Page backgrounds and body text are never green. Green marks things you interact with or things that identify the site. The canvas stays warm neutral.
 
 **The No-Neutrals Rule.** Every color in the system has chroma ≥ 0.007. Pure black (#000) and pure white (#fff) are prohibited. Even the darkest dark and brightest light carry a perceptible tint.
 
@@ -171,10 +171,9 @@ Shadows appear exclusively on hover feedback. The card hover state: subtle lift 
 
 ### Content Card
 
-- **Background:** Washi at rest. Pith on hover. Clay border reveal at hover.
-- **Border:** Linen Edge at 60% opacity at rest, full opacity + Clay on hover.
-- **Shadow:** None. Elevation from lift alone.
-- **Hover behavior:** Border solidifies with Clay tint, card lifts 2px, arrow icon shifts to Clay, 200ms ease-out.
+- **Background:** Card surface at rest. Popover surface on hover (one tonal step deeper).
+- **Border:** None. Tonal surface difference provides visual separation.
+- **Hover behavior:** Card scales 1.01% with ease-out, background deepens one tonal step, arrow icon shifts to green, 200ms ease-out.
 
 ### Tag Pill
 
@@ -190,21 +189,21 @@ Shadows appear exclusively on hover feedback. The card hover state: subtle lift 
 
 ### Header
 
-- **Logo:** "AS" in Clay, 20px, semibold. The Clay anchor of the page.
+- **Logo:** "AS" in green, 20px, semibold. The green anchor of the page.
 - **Border:** Bottom Linen Edge at 50% opacity.
 
 ### Footer
 
-- **Middot** between year and author name: Clay. The only Clay in the footer.
+- **Middot** between year and author name: green. The only green in the footer.
 - **Border:** Top Linen Edge at 50% opacity.
 
 ## 6. Do's and Don'ts
 
 ### Do:
 
-- **Do** use Clay on identity markers (logo, accent rules, section bars), interactive states (card hover borders, nav underlines, back links), prose links, tag pills, icon buttons, reading progress, TOC active headings. Clay is the system's voice.
+- **Do** use green on identity markers (logo, accent rules, section bars), interactive states (card hover tonal shift, nav underlines, back links), prose links, tag pills, icon buttons, reading progress, TOC active headings. Green is the system's voice.
 - **Do** tint every neutral toward warmth (OKLCH hue 50–80°). No surface should feel cold.
-- **Do** make hover states tangible. Cards lift and shadow. Nav links grow underlines. Arrows slide.
+- **Do** make hover states tangible. Cards scale and deepen. Nav links grow underlines. Arrows shift.
 - **Do** cap body text at 65–75ch. Reading comfort is non-negotiable.
 - **Do** use tonal surface steps (Unbleached > Washi > Pith) instead of shadows for depth.
 - **Do** keep both light and dark themes warm. The dark is not the opposite of the light.
@@ -212,6 +211,7 @@ Shadows appear exclusively on hover feedback. The card hover state: subtle lift 
 ### Don't:
 
 - **Don't** use pure black (#000) or pure white (#fff). Every surface and text color is tinted.
+- **Don't** use Clay or terracotta as the accent. The system has moved to a green accent. Update any remaining clay references.
 - **Don't** use side-stripe borders (border-left > 1px as accent). Blockquotes use a 2px left border; that's the one exception.
 - **Don't** use gradient text (background-clip: text with a gradient). Emphasis comes from weight or size.
 - **Don't** apply glassmorphism decoratively. All surfaces are opaque and tonal.

--- a/src/components/ContentCard.astro
+++ b/src/components/ContentCard.astro
@@ -15,8 +15,8 @@ interface Props {
 const { title, description, tags, href, meta, class: className } = Astro.props;
 ---
 
-<article class:list={cn("group", className)}>
-  <Link href={href} class:list={cn("block card-hover")} prefetch="hover">
+<article class:list={cn("group card-hover", className)}>
+  <Link href={href} class="block" prefetch="hover">
     <div class="flex flex-col gap-2 p-5">
       <div class="flex items-start justify-between gap-3">
         <h3

--- a/src/components/ContentCard.astro
+++ b/src/components/ContentCard.astro
@@ -26,7 +26,7 @@ const { title, description, tags, href, meta, class: className } = Astro.props;
         </h3>
         <Icon
           name="fa6-solid:arrow-right"
-          class="w-4 h-4 shrink-0 mt-1 text-muted-foreground/0 transition-all group-hover:translate-x-0.5"
+          class="w-4 h-4 shrink-0 mt-1 text-muted-foreground/40 transition-all group-hover:text-[var(--color-warm)] group-hover:translate-x-0.5"
         />
       </div>
       {meta && <p class="text-sm text-muted-foreground">{meta}</p>}

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,13 +3,13 @@ import SocialLinks from "@/components/SocialLinks.astro";
 import { SITE } from "@/consts";
 ---
 
-<section class="py-20 md:py-28">
+<section class="pt-28 pb-16 md:pt-40 md:pb-20">
   <div class="flex flex-col gap-6">
     <div class="page-enter">
       <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-foreground">
         {SITE.greeting}
       </h1>
-      <div class="mt-3 h-px w-12" style="background-color: var(--color-warm);" aria-hidden="true">
+      <div class="mt-3 h-px w-20" style="background-color: var(--color-warm);" aria-hidden="true">
       </div>
     </div>
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,7 +3,7 @@ import SocialLinks from "@/components/SocialLinks.astro";
 import { SITE } from "@/consts";
 ---
 
-<section class="pt-28 pb-16 md:pt-40 md:pb-20">
+<section class="pt-24 pb-14 md:pt-32 md:pb-18">
   <div class="flex flex-col gap-6">
     <div class="page-enter">
       <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-foreground">
@@ -18,7 +18,14 @@ import { SITE } from "@/consts";
     </p>
 
     <p class="text-foreground/75 max-w-2xl leading-relaxed page-enter page-enter-delay-2">
-      {SITE.heroIntro}
+      {
+        SITE.heroIntro.split("\n").map((line: string) => (
+          <>
+            {line}
+            <br />
+          </>
+        ))
+      }
     </p>
 
     <SocialLinks class="pt-2 page-enter page-enter-delay-3" />

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -20,12 +20,11 @@ const isExternal = external || href.startsWith("http");
   rel={isExternal ? "noopener noreferrer" : undefined}
   data-astro-prefetch={!isExternal && prefetch ? prefetch : undefined}
   class:list={cn(
-    "transition-colors ease-in-out",
     underline &&
       "underline decoration-muted-foreground underline-offset-[3px] hover:decoration-foreground",
     className
   )}
-  style={`transition-duration: var(--transition-slow);${style ? ` ${style}` : ""}`}
+  style={style}
   {...rest}
 >
   <slot />

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -19,7 +19,16 @@ const recentPosts = allPosts.slice(0, limit);
   recentPosts.length > 0 && (
     <section class:list={cn("flex flex-col gap-y-4", className)}>
       <div class="flex items-center justify-between">
-        <h2 class="text-lg font-semibold text-foreground">Latest Posts</h2>
+        <div class="flex items-center gap-2.5">
+          <div
+            class="w-[3px] h-4 rounded-sm shrink-0"
+            style="background-color: var(--color-warm);"
+            aria-hidden="true"
+          />
+          <span class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
+            Recent Writing
+          </span>
+        </div>
         <Link
           href="/blog"
           class="group inline-flex items-center gap-1.5 text-sm transition-colors"

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -10,9 +10,9 @@ export const SITE = {
 
   // Hero Section
   greeting: "Hey, I'm Abijith",
-  role: "Software Developer",
+  role: "Backend Engineer",
   heroIntro:
-    "Backend engineer in Kochi who got into programming because building things from scratch felt like the most satisfying kind of problem. I work with Java and Spring Boot by day, and I'm still figuring things out as I go. Outside of work, I'm into gaming, anime, and stories in all their forms.",
+    "Backend engineer in Kochi building things with Java and Spring Boot.\nI'm still figuring things out as I go.",
 
   // Pagination
   postsPerPage: 10,

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -9,10 +9,10 @@ export const SITE = {
   locale: "en-US",
 
   // Hero Section
-  greeting: "Abijith Suresh",
+  greeting: "Hey, I'm Abijith",
   role: "Software Developer",
   heroIntro:
-    "I build things for the web, mostly on the backend with Java and Spring Boot. I like clean code, good documentation, and solving problems that matter. Outside of work, I'm into gaming, anime, and stories in all their forms.",
+    "Backend engineer in Kochi who got into programming because building things from scratch felt like the most satisfying kind of problem. I work with Java and Spring Boot by day, and I'm still figuring things out as I go. Outside of work, I'm into gaming, anime, and stories in all their forms.",
 
   // Pagination
   postsPerPage: 10,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -99,5 +99,22 @@ const {
         // Don't set localStorage on first visit - let user's first manual toggle do that
       })();
     </script>
+
+    <script>
+      // First-load entrance animation: play once per session, skip on back-navigation
+      const entered = sessionStorage.getItem("site-entered");
+      if (!entered) {
+        sessionStorage.setItem("site-entered", "1");
+      } else {
+        document.querySelectorAll(".page-enter").forEach((el) => {
+          el.classList.remove(
+            "page-enter",
+            "page-enter-delay-1",
+            "page-enter-delay-2",
+            "page-enter-delay-3"
+          );
+        });
+      }
+    </script>
   </body>
 </html>

--- a/src/pages/api/og.png.ts
+++ b/src/pages/api/og.png.ts
@@ -9,12 +9,12 @@ export const GET: APIRoute = async ({ url }) => {
   const description = url.searchParams.get("description") || SITE.description;
   const type = url.searchParams.get("type") || "website";
 
-  // Ink & Clay theme colors
+  // Ink & Evergreen theme colors (OKLCH converted to hex for @vercel/og)
   const theme = {
-    background: "#faf8f5", // Light mode background (warm off-white)
-    foreground: "#1e1610", // Warm near-black text
-    accent: "#8f4028", // Clay accent
-    muted: "#7a6e68", // Warm stone gray
+    background: "#f9f6f2", // oklch(97.5% 0.007 80) — unbleached paper
+    foreground: "#150e0a", // oklch(17% 0.014 50) — warm near-black
+    accent: "#296944", // oklch(47% 0.09 155) — deep evergreen
+    muted: "#746d68", // oklch(54% 0.012 65) — warm stone gray
   };
 
   // Generate HTML for the OG image

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,18 @@
 ---
 import Hero from "@/components/Hero.astro";
+import ProjectCard from "@/components/ProjectCard.astro";
 import RecentPosts from "@/components/RecentPosts.astro";
+import Link from "@/components/Link.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
 import { getAllBlogPosts } from "@/lib/blog";
+import { getAllProjects } from "@/lib/projects";
+import { Icon } from "astro-icon/components";
 
 const allPosts = await getAllBlogPosts();
 const hasPosts = allPosts.length > 0;
+const allProjects = await getAllProjects();
+const hasProjects = allProjects.length > 0;
 ---
 
 <Layout
@@ -19,8 +25,47 @@ const hasPosts = allPosts.length > 0;
     <Hero />
 
     {
+      hasProjects && (
+        <section class="py-8 border-t border-border/50 page-enter page-enter-delay-1">
+          <div class="flex flex-col gap-y-4">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2.5">
+                <div
+                  class="w-[3px] h-4 rounded-sm shrink-0"
+                  style="background-color: var(--color-warm);"
+                  aria-hidden="true"
+                />
+                <span class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Featured Projects
+                </span>
+              </div>
+              <Link
+                href="/projects"
+                class="group inline-flex items-center gap-1.5 text-sm transition-colors"
+                style="color: var(--color-warm);"
+                prefetch="viewport"
+              >
+                View all
+                <Icon
+                  name="fa6-solid:arrow-right"
+                  class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5"
+                />
+              </Link>
+            </div>
+
+            <div class="flex flex-col gap-4">
+              {allProjects.map((project) => (
+                <ProjectCard project={project} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )
+    }
+
+    {
       hasPosts && (
-        <section class="py-12 border-t border-border/50 page-enter page-enter-delay-2">
+        <section class="py-8 border-t border-border/50 page-enter page-enter-delay-2">
           <RecentPosts />
         </section>
       )

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -40,7 +40,7 @@
 :root {
   /* ── Light theme: Unbleached Paper ─────────────────────────────────────── */
   --background: oklch(97.5% 0.007 80); /* barely-warm off-white, paper stock */
-  --foreground: oklch(17% 0.014 50); /* warm near-black, clay-tinted ink    */
+  --foreground: oklch(17% 0.014 50); /* warm near-black, green-tinted ink    */
 
   --card: oklch(95% 0.01 80); /* one step deeper than background     */
   --card-foreground: oklch(17% 0.014 50);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,12 +65,12 @@
 
   --border: oklch(88% 0.015 74); /* warm visible border                 */
   --input: oklch(88% 0.015 74);
-  --ring: oklch(47% 0.115 30); /* clay accent                         */
+  --ring: oklch(47% 0.065 30); /* clay accent                         */
 
   /* ── Clay accent ─────────────────────────────────────────────────────── */
-  --color-warm: oklch(47% 0.115 30); /* fired clay / red ochre              */
-  --color-warm-muted: oklch(47% 0.115 30 / 0.1);
-  --color-warm-subtle: oklch(47% 0.115 30 / 0.15);
+  --color-warm: oklch(47% 0.065 30); /* fired clay / red ochre              */
+  --color-warm-muted: oklch(47% 0.065 30 / 0.1);
+  --color-warm-subtle: oklch(47% 0.065 30 / 0.15);
 
   --transition-fast: 150ms;
   --transition-normal: 200ms;
@@ -106,12 +106,12 @@
 
   --border: oklch(28% 0.02 50); /* warm border                         */
   --input: oklch(28% 0.02 50);
-  --ring: oklch(69% 0.115 28); /* lighter clay — glows against warm dark */
+  --ring: oklch(69% 0.065 28); /* lighter clay — glows against warm dark */
 
   /* ── Clay accent (dark) ──────────────────────────────────────────────── */
-  --color-warm: oklch(69% 0.115 28); /* fired clay, lighter for dark mode   */
-  --color-warm-muted: oklch(69% 0.115 28 / 0.15);
-  --color-warm-subtle: oklch(69% 0.115 28 / 0.2);
+  --color-warm: oklch(69% 0.065 28); /* fired clay, lighter for dark mode   */
+  --color-warm-muted: oklch(69% 0.065 28 / 0.15);
+  --color-warm-subtle: oklch(69% 0.065 28 / 0.2);
 }
 
 /* Smooth theme transitions */
@@ -177,9 +177,7 @@
 
   .card-hover:hover {
     transform: translateY(-2px);
-    background: var(--color-warm-subtle);
     border-color: var(--color-warm);
-    box-shadow: 0 4px 12px rgb(0 0 0 / 0.06);
   }
 
   .group:hover .card-hover svg {
@@ -187,7 +185,7 @@
   }
 
   :where([data-theme="dark"]) .card-hover:hover {
-    box-shadow: 0 4px 12px rgb(0 0 0 / 0.3);
+    border-color: var(--color-warm);
   }
 
   .tag-pill {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -80,32 +80,32 @@
 
 [data-theme="dark"] {
   /* ── Dark theme: Workshop at Night ─────────────────────────────────────── */
-  --background: oklch(13.5% 0.016 50); /* warm dark — amber-shifted, not cool */
+  --background: oklch(13.5% 0.006 50); /* near-neutral dark with warm bias   */
   --foreground: oklch(93% 0.01 75); /* warm off-white                      */
 
-  --card: oklch(18% 0.018 50); /* slightly elevated warm surface      */
+  --card: oklch(18% 0.008 50); /* slightly elevated surface           */
   --card-foreground: oklch(93% 0.01 75);
 
-  --popover: oklch(22% 0.018 50); /* popover / deeper surface            */
+  --popover: oklch(22% 0.009 50); /* popover / deeper surface            */
   --popover-foreground: oklch(93% 0.01 75);
 
   --primary: oklch(93% 0.01 75);
-  --primary-foreground: oklch(13.5% 0.016 50);
+  --primary-foreground: oklch(13.5% 0.006 50);
 
-  --secondary: oklch(18% 0.018 50);
+  --secondary: oklch(18% 0.008 50);
   --secondary-foreground: oklch(93% 0.01 75);
 
-  --muted: oklch(22% 0.018 50);
-  --muted-foreground: oklch(58% 0.014 62); /* warm stone                         */
+  --muted: oklch(22% 0.009 50);
+  --muted-foreground: oklch(58% 0.01 55); /* warm stone                         */
 
-  --accent: oklch(18% 0.018 50);
+  --accent: oklch(18% 0.008 50);
   --accent-foreground: oklch(93% 0.01 75);
 
   --destructive: oklch(63% 0.22 20); /* brighter red for dark mode          */
-  --destructive-foreground: oklch(13.5% 0.016 50);
+  --destructive-foreground: oklch(13.5% 0.006 50);
 
-  --border: oklch(28% 0.02 50); /* warm border                         */
-  --input: oklch(28% 0.02 50);
+  --border: oklch(28% 0.01 50); /* subtle warm border                  */
+  --input: oklch(28% 0.01 50);
   --ring: oklch(69% 0.09 155); /* lighter green — glows against warm dark */
 
   /* ── Green accent (dark) ─────────────────────────────────────────────── */
@@ -170,15 +170,15 @@
 
 @layer components {
   .card-hover {
-    @apply rounded-lg overflow-hidden;
+    @apply rounded-lg overflow-hidden border border-border;
     background: var(--card);
     @apply transition-all;
-    transition-duration: var(--transition-normal);
-    transition-timing-function: ease-out;
+    transition-duration: 250ms;
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   .card-hover:hover {
-    transform: scale(1.01);
+    transform: scale(1.015);
     background: var(--popover);
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,12 +65,12 @@
 
   --border: oklch(88% 0.015 74); /* warm visible border                 */
   --input: oklch(88% 0.015 74);
-  --ring: oklch(47% 0.065 30); /* clay accent                         */
+  --ring: oklch(47% 0.09 155); /* green accent                        */
 
-  /* ── Clay accent ─────────────────────────────────────────────────────── */
-  --color-warm: oklch(47% 0.065 30); /* fired clay / red ochre              */
-  --color-warm-muted: oklch(47% 0.065 30 / 0.1);
-  --color-warm-subtle: oklch(47% 0.065 30 / 0.15);
+  /* ── Green accent ────────────────────────────────────────────────────── */
+  --color-warm: oklch(47% 0.09 155); /* deep evergreen                      */
+  --color-warm-muted: oklch(47% 0.09 155 / 0.1);
+  --color-warm-subtle: oklch(47% 0.09 155 / 0.15);
 
   --transition-fast: 150ms;
   --transition-normal: 200ms;
@@ -106,12 +106,12 @@
 
   --border: oklch(28% 0.02 50); /* warm border                         */
   --input: oklch(28% 0.02 50);
-  --ring: oklch(69% 0.065 28); /* lighter clay — glows against warm dark */
+  --ring: oklch(69% 0.09 155); /* lighter green — glows against warm dark */
 
-  /* ── Clay accent (dark) ──────────────────────────────────────────────── */
-  --color-warm: oklch(69% 0.065 28); /* fired clay, lighter for dark mode   */
-  --color-warm-muted: oklch(69% 0.065 28 / 0.15);
-  --color-warm-subtle: oklch(69% 0.065 28 / 0.2);
+  /* ── Green accent (dark) ─────────────────────────────────────────────── */
+  --color-warm: oklch(69% 0.09 155); /* lighter evergreen for dark mode     */
+  --color-warm-muted: oklch(69% 0.09 155 / 0.15);
+  --color-warm-subtle: oklch(69% 0.09 155 / 0.2);
 }
 
 /* Smooth theme transitions */
@@ -170,22 +170,20 @@
 
 @layer components {
   .card-hover {
-    @apply rounded-lg overflow-hidden border border-border/60;
+    @apply rounded-lg overflow-hidden;
+    background: var(--card);
     @apply transition-all;
     transition-duration: var(--transition-normal);
+    transition-timing-function: ease-out;
   }
 
   .card-hover:hover {
-    transform: translateY(-2px);
-    border-color: var(--color-warm);
+    transform: scale(1.01);
+    background: var(--popover);
   }
 
   .group:hover .card-hover svg {
     color: var(--color-warm);
-  }
-
-  :where([data-theme="dark"]) .card-hover:hover {
-    border-color: var(--color-warm);
   }
 
   .tag-pill {

--- a/src/themes/ink-and-paper.ts
+++ b/src/themes/ink-and-paper.ts
@@ -37,34 +37,34 @@ const inkAndPaper: ThemeDefinition = {
   },
 
   // Dark theme: Workshop at Night
-  // Warm amber-shifted dark (not cool midnight), clay accent glows brighter.
+  // Near-neutral dark with warm bias (hue 50), green accent carries the color.
   dark: {
-    background: "oklch(13.5% 0.016 50)",
+    background: "oklch(13.5% 0.006 50)",
     foreground: "oklch(93% 0.010 75)",
 
-    card: "oklch(18% 0.018 50)",
+    card: "oklch(18% 0.008 50)",
     cardForeground: "oklch(93% 0.010 75)",
 
-    popover: "oklch(22% 0.018 50)",
+    popover: "oklch(22% 0.009 50)",
     popoverForeground: "oklch(93% 0.010 75)",
 
     primary: "oklch(93% 0.010 75)",
-    primaryForeground: "oklch(13.5% 0.016 50)",
+    primaryForeground: "oklch(13.5% 0.006 50)",
 
-    secondary: "oklch(18% 0.018 50)",
+    secondary: "oklch(18% 0.008 50)",
     secondaryForeground: "oklch(93% 0.010 75)",
 
-    muted: "oklch(22% 0.018 50)",
-    mutedForeground: "oklch(58% 0.014 62)",
+    muted: "oklch(22% 0.009 50)",
+    mutedForeground: "oklch(58% 0.010 55)",
 
-    accent: "oklch(18% 0.018 50)",
+    accent: "oklch(18% 0.008 50)",
     accentForeground: "oklch(93% 0.010 75)",
 
     destructive: "oklch(63% 0.22 20)",
-    destructiveForeground: "oklch(13.5% 0.016 50)",
+    destructiveForeground: "oklch(13.5% 0.006 50)",
 
-    border: "oklch(28% 0.020 50)",
-    input: "oklch(28% 0.020 50)",
+    border: "oklch(28% 0.010 50)",
+    input: "oklch(28% 0.010 50)",
     ring: "oklch(69% 0.09 155)",
   },
 };

--- a/src/themes/ink-and-paper.ts
+++ b/src/themes/ink-and-paper.ts
@@ -33,7 +33,7 @@ const inkAndPaper: ThemeDefinition = {
 
     border: "oklch(88% 0.015 74)",
     input: "oklch(88% 0.015 74)",
-    ring: "oklch(47% 0.065 30)",
+    ring: "oklch(47% 0.09 155)",
   },
 
   // Dark theme: Workshop at Night
@@ -65,7 +65,7 @@ const inkAndPaper: ThemeDefinition = {
 
     border: "oklch(28% 0.020 50)",
     input: "oklch(28% 0.020 50)",
-    ring: "oklch(69% 0.065 28)",
+    ring: "oklch(69% 0.09 155)",
   },
 };
 

--- a/src/themes/ink-and-paper.ts
+++ b/src/themes/ink-and-paper.ts
@@ -33,7 +33,7 @@ const inkAndPaper: ThemeDefinition = {
 
     border: "oklch(88% 0.015 74)",
     input: "oklch(88% 0.015 74)",
-    ring: "oklch(47% 0.115 30)",
+    ring: "oklch(47% 0.065 30)",
   },
 
   // Dark theme: Workshop at Night
@@ -65,7 +65,7 @@ const inkAndPaper: ThemeDefinition = {
 
     border: "oklch(28% 0.020 50)",
     input: "oklch(28% 0.020 50)",
-    ring: "oklch(69% 0.115 28)",
+    ring: "oklch(69% 0.065 28)",
   },
 };
 

--- a/src/themes/ink-and-paper.ts
+++ b/src/themes/ink-and-paper.ts
@@ -2,10 +2,10 @@ import type { ThemeDefinition } from "./types";
 
 const inkAndPaper: ThemeDefinition = {
   name: "ink-and-paper",
-  displayName: "Ink & Clay",
+  displayName: "Ink & Evergreen",
 
   // Light theme: Unbleached Paper
-  // Warm off-white canvas, clay-tinted near-black text, warm stone muted.
+  // Warm off-white canvas, green-tinted near-black text, warm stone muted.
   light: {
     background: "oklch(97.5% 0.007 80)",
     foreground: "oklch(17% 0.014 50)",


### PR DESCRIPTION
## Summary

Improves the landing page across hero copy, visual hierarchy, color identity, card interactions, and animation behavior. Based on a design critique against PRODUCT.md and DESIGN.md principles.

## Changes

### Hero
- Rewrite greeting to conversational first-person voice ("Hey, I'm Abijith") with two focused sentences separated by a line break
- Change tagline from "Software Developer" to "Backend Engineer" for specificity
- Widen hero rule from `w-12` to `w-20` for a confident compositional element
- Adjust spacing to `pt-24 md:pt-32` — generous but not excessive

### Color
- Replace clay accent (OKLCH hue 30) with deep evergreen (OKLCH hue 155, chroma 0.09) for a more grounded, confident identity
- Green reads as systems-that-work: a successful build, a healthy indicator light
- Warm neutrals kept — green-on-warm is a natural complementary pair (green tools on a warm bench)
- Updated in global.css, theme file, and OG image generation

### Landing page
- Add Featured Projects section, pulling from the projects collection
- Replace "Latest Posts" heading with uppercase tracked label treatment ("RECENT WRITING"), matching about page section markers

### Card interactions
- Remove card borders entirely; cards use tonal surface steps (card → popover) for visual separation
- Replace translateY(-2px) hover with subtle scale(1.01) and tonal background wash
- Show card arrow at ~40% opacity at rest, transitioning to green on hover
- Hover is now: scale + tonal deepening + arrow shift — smooth and organic, no hard edges

### Animation
- Limit entrance animation to first page load per session; subsequent navigations skip the staggered reveal

### Documentation
- Update DESIGN.md for new green accent, simplified card hover, and updated design rationale
- Update CHANGELOG.md with all changes

## Testing

- [ ] Visual check: hero copy reads personal and specific, with a clean line break
- [ ] Visual check: tagline shows "Backend Engineer"
- [ ] Visual check: green accent reads as confident and grounded, not teal or neon
- [ ] Visual check: green works well in both light and dark modes
- [ ] Visual check: warm neutrals complement the green accent
- [ ] Visual check: Featured Projects section appears between hero and blog posts
- [ ] Visual check: cards have no borders at rest, with tonal surface difference visible
- [ ] Interaction: card hover is smooth scale + tonal wash + arrow shift, no jarring edges
- [ ] Interaction: navigate away from home and back, entrance animation should not replay
- [ ] Verify blog posts, about page, and other routes still look correct
- [ ] `bun run verify` passes

## References

- Ticket/Issue: N/A