### PR TITLE
feat: add two-font system and fix about page violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,32 +8,37 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 
 ### Added
 
-- Featured Projects section to the landing page, pulling project cards from the projects collection.
-- Two-font typographic system: Clash Display for identity surfaces (hero, page titles, section labels, detail titles) paired with Satoshi for content surfaces (body text, cards, navigation, meta).
-- Two-layered section labels with a Clash Display primary label and a Satoshi descriptive sublabel across landing, about, blog, and projects pages.
+- Featured Projects section on the landing page, pulling project cards from the projects collection.
+- Bricolage Grotesque variable font (weight 200–800, optical sizing 12–96) as the display typeface, establishing a two-family system: Bricolage for identity surfaces (hero, page titles, section headings), Satoshi for content surfaces (body, cards, nav, meta).
+- Two-layered section labels across all pages: a bold Bricolage Grotesque heading paired with a Satoshi muted sublabel on the row below, with "View all" utility links baseline-aligned to the sublabel.
 
 ### Changed
 
-- Rewrote the hero greeting to a conversational first-person voice ("Hey, I'm Abijith"), shortened the intro to two focused sentences with a line break, and changed the tagline from "Software Developer" to "Backend Engineer".
+- Rewrote the hero greeting to a conversational first-person voice ("Hey, I'm Abijith"), shortened the intro copy, and updated the role from "Software Developer" to "Backend Engineer".
 - Widened the hero accent rule from `w-12` to `w-20` so it reads as a confident compositional element rather than a tick mark.
-- Adjusted hero spacing to `pt-24 md:pt-32` for generous but not excessive breathing room; tightened content sections to `py-8` for a focused rhythm.
-- Replaced the "Latest Posts" heading with the uppercase tracked label treatment ("RECENT WRITING"), matching the about page's section markers and letting card titles stay the visual focus.
-- Made content card hover arrows visible at ~40% opacity at rest, transitioning to evergreen on hover for better clickability affordance.
-- Entrance animations now play only on the first page load per session; subsequent navigations skip the staggered reveal for a snappier experience.
-- Replaced clay accent with deep evergreen (OKLCH hue 155, chroma 0.09) for a more grounded, confident identity that works in both light and dark themes.
-- Removed card borders entirely; cards now use tonal surface steps (card → popover) for visual separation.
-- Replaced card translate-y hover with subtle scale(1.01) and tonal background wash for a smoother, more organic feel.
-- Updated DESIGN.md to document the new green accent and simplified card hover behavior.
-- Restored card borders as a static 1px element that does not participate in hover state.
-- Replaced card hover easing from generic `ease-out` to ease-out-quint (`cubic-bezier(0.22, 1, 0.36, 1)`) with 250ms duration for a smoother settle into place.
-- Increased card hover scale from 1.01 to 1.015 for perceptible but subtle movement.
-- Reduced dark theme surface chroma from 0.016–0.020 to 0.006–0.010 (near-neutral with warm bias) to eliminate the reddish-brown cast and let the green accent dominate the canvas.
-- Removed forced transitions from `Link.astro` (it now provides semantics only) and moved `card-hover` from the link to the article wrapper in `ContentCard.astro`, fixing a cascade conflict where Link's `transition-colors` excluded `transform` from the animated properties.
-- Removed side-stripe accent bars from section labels (about page, landing page, recent posts) to comply with the design system's own ban on side-stripe borders.
-- Replaced `text-foreground/80` and `text-foreground/70` with `text-foreground` on the about page to fix WCAG AA contrast failures on the light theme.
-- Replaced single-line section labels with two-layered format (Clash Display primary + Satoshi descriptive sublabel) across all pages.
-- Updated blog and projects listing page titles to use the display font with a descriptive sublabel.
-- Updated DESIGN.md typography section to document the Clash Display + Satoshi pairing and label pair rules.
+- Adjusted hero spacing to `pt-24 md:pt-32` for generous breathing room; tightened content sections to `py-8`.
+- Made content card hover arrows visible at ~40% opacity at rest, transitioning to evergreen on hover.
+- Entrance animations now play only on the first page load per session; subsequent navigations skip the staggered reveal.
+- Replaced clay accent with deep evergreen (OKLCH hue 155, chroma 0.09) across both themes.
+- Card borders restored as a static 1px element; hover uses scale(1.015) with ease-out-quint (250ms) and a tonal background deepening instead of translate-y.
+- Reduced dark theme surface chroma to 0.006–0.010 (near-neutral warm bias) to eliminate the reddish-brown cast and let the green accent read clearly.
+- Removed forced transitions from `Link.astro` and moved `card-hover` to the article wrapper in `ContentCard.astro`, fixing a cascade conflict that blocked transform animations.
+- Replaced small uppercase tracked section labels with bold display headings site-wide. Section landmarks now use `text-2xl sm:text-3xl font-bold font-display` with a `text-base` Satoshi sublabel below.
+- Moved "View all" links from the heading row to the sublabel row (`items-baseline` aligned) so the heading owns its line without competition.
+- Updated homepage section sublabels: Projects → "What I've built", Writing → "Thoughts in public".
+- Updated blog listing sublabel to "Notes, write-ups, and the occasional opinion".
+- Updated projects listing sublabel to "Shipped work, side projects, and experiments".
+- Redesigned the about page header from a centered stack to a horizontal avatar-and-name layout.
+- Rewrote all about page copy with three named narrative sections replacing the previous single-blob origin story: "What I do" (current role and craft focus at UST), "How I got here" (honest path without the usual clichés), and "This site" (matter-of-fact about what the writing is for).
+- Updated the about page tagline from "Developer, builder, writer." to "Backend engineer at UST. Kochi, Kerala."
+- Promoted "Away from the keyboard" from a visually separated aside to a peer section with the same spacing and weight as the other sections; interests now display as evergreen tag pills matching the site's tagging system.
+- Bumped the about page `h1` from `text-3xl sm:text-4xl` to `text-4xl sm:text-5xl` to restore a 1.6:1 ratio against section `h2` headings.
+- Updated DESIGN.md: two-family typography rule, section heading rule, page title hierarchy rule, and a seven-level type scale table.
+
+### Fixed
+
+- Removed `text-foreground/80` and `text-foreground/70` on the about page, which failed WCAG AA contrast on the light theme (3.21:1 and 2.69:1 respectively); replaced with full `text-foreground` (4.68:1).
+- Removed side-stripe accent divs (`w-[3px]` colored bars) from the about page, landing page, and recent posts component, in compliance with the design system's own ban on side-stripe borders.
 
 ## 2026-05-01 — Repository metadata cleanup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 ### Added
 
 - Featured Projects section to the landing page, pulling project cards from the projects collection.
+- Two-font typographic system: Clash Display for identity surfaces (hero, page titles, section labels, detail titles) paired with Satoshi for content surfaces (body text, cards, navigation, meta).
+- Two-layered section labels with a Clash Display primary label and a Satoshi descriptive sublabel across landing, about, blog, and projects pages.
 
 ### Changed
 
@@ -27,6 +29,11 @@ This changelog follows the categories and intent of [Keep a Changelog](https://k
 - Increased card hover scale from 1.01 to 1.015 for perceptible but subtle movement.
 - Reduced dark theme surface chroma from 0.016–0.020 to 0.006–0.010 (near-neutral with warm bias) to eliminate the reddish-brown cast and let the green accent dominate the canvas.
 - Removed forced transitions from `Link.astro` (it now provides semantics only) and moved `card-hover` from the link to the article wrapper in `ContentCard.astro`, fixing a cascade conflict where Link's `transition-colors` excluded `transform` from the animated properties.
+- Removed side-stripe accent bars from section labels (about page, landing page, recent posts) to comply with the design system's own ban on side-stripe borders.
+- Replaced `text-foreground/80` and `text-foreground/70` with `text-foreground` on the about page to fix WCAG AA contrast failures on the light theme.
+- Replaced single-line section labels with two-layered format (Clash Display primary + Satoshi descriptive sublabel) across all pages.
+- Updated blog and projects listing page titles to use the display font with a descriptive sublabel.
+- Updated DESIGN.md typography section to document the Clash Display + Satoshi pairing and label pair rules.
 
 ## 2026-05-01 — Repository metadata cleanup
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,19 +20,19 @@ colors:
   ember-red: "oklch(63% 0.22 20)"
 typography:
   display:
-    fontFamily: "Satoshi, system-ui, sans-serif"
+    fontFamily: "Clash Display, Satoshi, system-ui, sans-serif"
     fontSize: "clamp(2.25rem, 6vw, 3.75rem)"
     fontWeight: 700
     lineHeight: 1.1
     letterSpacing: "-0.025em"
   headline:
-    fontFamily: "Satoshi, system-ui, sans-serif"
+    fontFamily: "Clash Display, Satoshi, system-ui, sans-serif"
     fontSize: "1.5rem"
     fontWeight: 600
     lineHeight: 1.3
     letterSpacing: "normal"
   title:
-    fontFamily: "Satoshi, system-ui, sans-serif"
+    fontFamily: "Clash Display, Satoshi, system-ui, sans-serif"
     fontSize: "1.25rem"
     fontWeight: 600
     lineHeight: 1.4
@@ -44,8 +44,8 @@ typography:
     lineHeight: 1.625
     letterSpacing: "normal"
   label:
-    fontFamily: "Satoshi, system-ui, sans-serif"
-    fontSize: "0.8125rem"
+    fontFamily: "Clash Display, Satoshi, system-ui, sans-serif"
+    fontSize: "0.875rem"
     fontWeight: 600
     lineHeight: 1
     letterSpacing: "0.05em"
@@ -136,23 +136,27 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 
 ## 3. Typography
 
-**Display Font:** Satoshi (system-ui, sans-serif fallback)  
-**Body Font:** Satoshi (same family; weight and scale create hierarchy)  
-**Label Font:** Satoshi (uppercase, wide tracking distinguishes labels from body)
+**Display Font:** Clash Display (Satoshi, system-ui, sans-serif fallback)
+**Body Font:** Satoshi (system-ui, sans-serif fallback)
+**Label Font:** Clash Display (same as display; uppercase, wide tracking distinguishes labels from body)
 
-**Character:** Satoshi is a geometric sans with just enough warmth in its terminals to feel human. Single-family: hierarchy lives entirely in weight (400 to 700) and scale (0.8125rem to 3.75rem). No serif/sans personality crutch.
+**Character:** Two-family pairing from the same foundry (Indian Type Foundry / Fontshare). Clash Display is a bold grotesque with personality at large sizes — slightly quirky terminals and a confident stance that reads as deliberate, not decorated. Satoshi is a geometric sans with warmth in its terminals, handling body text and functional UI with clean readability. The pairing creates structural hierarchy through typeface contrast: identity surfaces (display, headlines, titles, labels) use Clash Display; content and utility (body, nav, meta, cards) use Satoshi. The two families share enough geometric DNA to feel cohesive, but differ enough at display sizes to create instant visual distinction.
 
 ### Hierarchy
 
-- **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero name. Single largest element. Negative tracking keeps it confident.
-- **Headline** (600, 1.5rem, line-height 1.3): Blog post titles, section headings.
-- **Title** (600, 1.25rem, line-height 1.4): Card titles, secondary headings.
-- **Body** (400, 1rem, line-height 1.625): All running content. Max 65–75ch line length.
-- **Label** (600, 0.8125rem, letter-spacing 0.05em, uppercase): Section markers. Used sparingly.
+- **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero greeting, about page name. Clash Display. Single largest element. Negative tracking keeps it confident.
+- **Headline** (600, 1.5rem–2rem, line-height 1.3): Blog post titles, project detail titles. Clash Display.
+- **Title** (600, 1.5rem, line-height 1.4): Page titles on listing pages (Blog, Projects, Tags). Clash Display.
+- **Body** (400, 1rem, line-height 1.625): All running content. Satoshi. Max 65–75ch line length.
+- **Label primary** (600, 0.875rem, letter-spacing 0.05em, uppercase): Section markers (“Background”, “Featured Projects”). Clash Display.
+- **Label secondary** (400, 0.875rem, sentence case): Descriptive sublabels (“How I got here”, “Things I'm building”). Satoshi. Softer voice beneath the label.
+- **Card title** (600, 1.125rem): Blog and project card titles. Satoshi — cards are functional density, not identity.
 
 ### Named Rules
 
-**The Scale-Only Rule.** One typeface means hierarchy from weight and size contrast alone. Adjacent heading levels must differ by ≥1.25× in size or one full weight step. Flat hierarchies are prohibited.
+**The Two-Family Rule.** Identity surfaces (display, headlines, page titles, labels) use Clash Display. Content surfaces (body, cards, nav, meta, breadcrumbs, tags) use Satoshi. The boundary is strict: if it announces identity or structure, it's Clash Display. If it's content to be read, it's Satoshi.
+
+**The Label Pair Rule.** Section labels are always two-layered: a Clash Display primary label (uppercase, tracked) and a Satoshi secondary line (sentence case, softer). The secondary line is the voice; the primary line is the structure. Both appear together.
 
 **The Writing-First Rule.** Blog prose typography takes priority. Body line height (1.625) and line length (65–75ch) are tuned for long-form reading comfort. Everything else accommodates this.
 
@@ -206,6 +210,8 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 - **Do** cap body text at 65–75ch. Reading comfort is non-negotiable.
 - **Do** use tonal surface steps (Unbleached > Washi > Pith) instead of shadows for depth.
 - **Do** keep both light and dark themes warm. The dark is not the opposite of the light.
+- **Do** use Clash Display for identity surfaces (hero, page titles, section labels, detail titles) and Satoshi for content surfaces (body, cards, nav, meta). The boundary is identity vs content.
+- **Do** pair section labels with a secondary descriptive line in Satoshi (sentence case, softer).
 
 ### Don't:
 
@@ -218,3 +224,5 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 - **Don't** use Evergreen as a large background fill or body text color. It marks identity and interaction, not surfaces.
 - **Don't** let the dark theme go cool. Ironwood (warm amber-shifted dark) is not negotiable.
 - **Don't** add 3D scenes, particle effects, scroll-jacking, or WebGL showcases. The craft shows in precision, not spectacle.
+- **Don't** use Clash Display for body text, card titles, or functional UI elements. It's an identity font, not a reading font.
+- **Don't** use Satoshi for page-level titles or section labels when Clash Display is available. The typographic contrast is the hierarchy.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -142,20 +142,28 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 
 **Character:** Two-family pairing chosen for genuine structural contrast. Bricolage Grotesque is a variable grotesque (weight 200–800, optical sizing 12–96) with origins in rough letterpress and industrial signage traditions. Where most geometric sans-serifs optimize for smooth, even strokes, Bricolage carries deliberate irregularity — slight ink traps, optically compensated junctions, letterforms that read as made rather than drawn. At display sizes with optical sizing maxed, it reads as a precision tool used with intent, which maps directly to this site's "craftsman's desk" identity. Satoshi is a refined, warm geometric sans that handles body text and functional UI with clean readability. The contrast is meaningful: Bricolage (rough, expressive, artisanal) for identity surfaces; Satoshi (polished, warm, readable) for content. The pairing tells the same story the color system does — intentional craft, not corporate uniformity.
 
-### Hierarchy
+### Type Scale
 
-- **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero greeting, about page name. Bricolage Grotesque. Single largest element. Negative tracking keeps it confident.
-- **Headline** (700, 1.875rem–2.25rem, line-height 1.2, tracking -0.015em): Page titles on listing pages (Blog, Projects); about page and homepage section headings (Background, Projects, Writing). Bricolage Grotesque.
-- **Title** (700, 1.5rem, line-height 1.3): Blog post titles, project detail titles. Bricolage Grotesque.
-- **Body** (400, 1rem, line-height 1.625): All running content. Satoshi. Max 65–75ch line length.
-- **Section sublabel** (400, 0.875rem, sentence case): Descriptive line beneath section headings ("How I got here", "Things I'm building"). Satoshi. Muted. Softer voice beneath the heading.
-- **Card title** (600, 1.125rem): Blog and project card titles. Satoshi — cards are functional density, not identity.
+Seven semantic levels. Each maps to one explicit Tailwind class combination. No arbitrary sizes.
+
+| Level        | Role                               | Tailwind classes                                            | Desktop px  | Font      | Notes                                                        |
+| ------------ | ---------------------------------- | ----------------------------------------------------------- | ----------- | --------- | ------------------------------------------------------------ |
+| Display      | Hero greeting                      | `text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight` | 60px        | Bricolage | Absolute maximum. Homepage only.                             |
+| Page title   | About page identity                | `text-4xl sm:text-5xl font-bold tracking-tight`             | 48px        | Bricolage | About h1. Must be 1.5× section h2 on desktop.                |
+| Page heading | Listing / detail page h1           | `text-3xl sm:text-4xl font-bold tracking-tight`             | 36px        | Bricolage | Blog, Projects, Tags, post/project titles. No competing h2s. |
+| Section h2   | Homepage + about section landmarks | `text-2xl sm:text-3xl font-bold tracking-tight`             | 30px        | Bricolage | Always paired with a sublabel.                               |
+| Card title   | Individual item titles             | `text-lg font-medium`                                       | 18px        | Satoshi   | Cards are content, not identity.                             |
+| Body         | Running prose                      | (base, 1rem)                                                | 16px        | Satoshi   | Line height 1.625. Max 65–75ch.                              |
+| Sublabel     | Section companion descriptions     | `text-base text-muted-foreground`                           | 16px        | Satoshi   | Paired with section h2. Always sentence case.                |
+| Utility      | Nav, meta, tags, actions           | `text-sm` / `text-xs`                                       | 14px / 12px | Satoshi   | Nav, breadcrumb, card meta, "View all" actions, tag pills.   |
 
 ### Named Rules
 
 **The Two-Family Rule.** Identity surfaces (display, headlines, page titles, section headings) use Bricolage Grotesque. Content surfaces (body, cards, nav, meta, breadcrumbs, tags) use Satoshi. The boundary is identity vs content.
 
-**The Section Heading Rule.** Section landmarks are always two-layered: a Bricolage Grotesque heading (bold, tracking-tight, 1.5rem–1.875rem, Title Case) and a Satoshi sublabel (sentence case, muted, text-base). Both appear together. The heading announces structure; the sublabel is the voice.
+**The Section Heading Rule.** Section landmarks are always two-layered: heading row (full-width Bricolage h2, bold, tracking-tight, Title Case) above a sublabel row (Satoshi `text-base` muted description on the left, "View all" utility link on the right, `items-baseline` aligned). The heading owns its row without competition. The sublabel and action share the subordinate row as a matched pair. Gap between rows: `gap-1` (4px).
+
+**The Page Title Hierarchy Rule.** About page h1 uses `text-4xl sm:text-5xl` — one level above section h2s (`text-2xl sm:text-3xl`). This gives a 1.6:1 ratio on desktop (48:30px). Any page with section h2s visible simultaneously must have its h1 maintain at minimum a 1.5:1 ratio against those h2s. Listing/detail pages with no competing h2s may use `text-3xl sm:text-4xl`.
 
 **The Writing-First Rule.** Blog prose typography takes priority. Body line height (1.625) and line length (65-75ch) are tuned for long-form reading comfort. Everything else accommodates this.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -145,7 +145,7 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 ### Hierarchy
 
 - **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero greeting, about page name. Bricolage Grotesque. Single largest element. Negative tracking keeps it confident.
-- **Headline** (700, 1.875rem–2.25rem, line-height 1.2, tracking -0.015em): Page titles on listing pages (Blog., Projects.); about page and homepage section headings (Background., Projects., Writing.). Bricolage Grotesque. Trailing period is the personality marker.
+- **Headline** (700, 1.875rem–2.25rem, line-height 1.2, tracking -0.015em): Page titles on listing pages (Blog, Projects); about page and homepage section headings (Background, Projects, Writing). Bricolage Grotesque.
 - **Title** (700, 1.5rem, line-height 1.3): Blog post titles, project detail titles. Bricolage Grotesque.
 - **Body** (400, 1rem, line-height 1.625): All running content. Satoshi. Max 65–75ch line length.
 - **Section sublabel** (400, 0.875rem, sentence case): Descriptive line beneath section headings ("How I got here", "Things I'm building"). Satoshi. Muted. Softer voice beneath the heading.
@@ -155,7 +155,7 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 
 **The Two-Family Rule.** Identity surfaces (display, headlines, page titles, section headings) use Bricolage Grotesque. Content surfaces (body, cards, nav, meta, breadcrumbs, tags) use Satoshi. The boundary is identity vs content.
 
-**The Section Heading Rule.** Section landmarks are always two-layered: a Bricolage Grotesque heading (bold, tracking-tight, 1.5rem–1.875rem, Title Case, trailing period) and a Satoshi sublabel (sentence case, muted, text-sm). The period is the personality marker — it reads as deliberate and finished, not template-generated. Both appear together. The heading announces structure; the sublabel is the voice.
+**The Section Heading Rule.** Section landmarks are always two-layered: a Bricolage Grotesque heading (bold, tracking-tight, 1.5rem–1.875rem, Title Case) and a Satoshi sublabel (sentence case, muted, text-base). Both appear together. The heading announces structure; the sublabel is the voice.
 
 **The Writing-First Rule.** Blog prose typography takes priority. Body line height (1.625) and line length (65-75ch) are tuned for long-form reading comfort. Everything else accommodates this.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 ---
 name: "abijith.sh"
-description: "Personal portfolio and blog of Abijith S — one backend engineer's home on the web"
+description: "Personal portfolio and blog of Abijith S - one backend engineer's home on the web"
 colors:
   evergreen: "oklch(47% 0.09 155)"
   evergreen-light: "oklch(69% 0.09 155)"
@@ -20,19 +20,19 @@ colors:
   ember-red: "oklch(63% 0.22 20)"
 typography:
   display:
-    fontFamily: "Clash Display, Satoshi, system-ui, sans-serif"
+    fontFamily: "Space Grotesk, Satoshi, system-ui, sans-serif"
     fontSize: "clamp(2.25rem, 6vw, 3.75rem)"
     fontWeight: 700
     lineHeight: 1.1
     letterSpacing: "-0.025em"
   headline:
-    fontFamily: "Clash Display, Satoshi, system-ui, sans-serif"
+    fontFamily: "Space Grotesk, Satoshi, system-ui, sans-serif"
     fontSize: "1.5rem"
     fontWeight: 600
     lineHeight: 1.3
     letterSpacing: "normal"
   title:
-    fontFamily: "Clash Display, Satoshi, system-ui, sans-serif"
+    fontFamily: "Space Grotesk, Satoshi, system-ui, sans-serif"
     fontSize: "1.25rem"
     fontWeight: 600
     lineHeight: 1.4
@@ -44,8 +44,8 @@ typography:
     lineHeight: 1.625
     letterSpacing: "normal"
   label:
-    fontFamily: "Clash Display, Satoshi, system-ui, sans-serif"
-    fontSize: "0.875rem"
+    fontFamily: "Space Grotesk, Satoshi, system-ui, sans-serif"
+    fontSize: "1.125rem"
     fontWeight: 600
     lineHeight: 1
     letterSpacing: "0.05em"
@@ -83,11 +83,11 @@ components:
 
 Warm materials, everything in its place, the tools of someone who takes pride in their work. This system draws from the feeling of a well-organized workshop at different hours of the day: unbleached paper under good afternoon light, the same desk by lamplight in the evening. Every surface is intentional. Nothing is ornamental for its own sake.
 
-**Color reference:** _A well-kept workshop at different hours of the day — green-handled precision tools on unbleached paper under good afternoon light, the same bench by lamplight in the evening. Green as the color of systems that work: a successful build, a healthy indicator light, a well-maintained machine. The dark theme uses near-neutral surfaces with a warm bias, so the green accent becomes the dominant chromatic signal — the only color in the room. Every surface is intentional. Nothing is ornamental for its own sake._
+**Color reference:** _A well-kept workshop at different hours of the day - green-handled precision tools on unbleached paper under good afternoon light, the same bench by lamplight in the evening. Green as the color of systems that work: a successful build, a healthy indicator light, a well-maintained machine. The dark theme uses near-neutral surfaces with a warm bias, so the green accent becomes the dominant chromatic signal - the only color in the room. Every surface is intentional. Nothing is ornamental for its own sake._
 
 The palette uses warm neutrals paired with a deep evergreen accent. The green breaks from the warm-red/terracotta convention and gives the site a grounded, technical identity. The light theme is unbleached paper under good light; the dark theme is the same workshop after sundown, with the amber warmth of the desk lamp casting everything in the same hue family. Green carries identity and interaction; warm neutrals carry the canvas.
 
-**Color strategy: Committed** — Green carries ~40% of the site's identity surfaces: hero role text, the horizontal rule below the name, prose links, tag pills, active nav states, icon buttons, TOC active headings, and reading progress. The canvas is never green. Green marks identity and interaction. That's its job.
+**Color strategy: Committed** - Green carries ~40% of the site's identity surfaces: hero role text, the horizontal rule below the name, prose links, tag pills, active nav states, icon buttons, TOC active headings, and reading progress. The canvas is never green. Green marks identity and interaction. That's its job.
 
 **Key Characteristics:**
 
@@ -102,9 +102,9 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 ### Accent
 
 - **Evergreen** (`oklch(47% 0.09 155)`): The sole accent. Deep forest green, grounded and confident. Used for the logo, horizontal rule, prose links, tag pills, active nav, icon buttons, TOC active headings, and reading progress. Passes WCAG AA on the light background. Never used as a background fill or large surface color.
-- **Evergreen Light** (`oklch(69% 0.09 155)`): Dark theme variant. Same hue family, higher lightness. Passes WCAG AA on the dark background. Keeps the same character — green indicator light caught in warm lamplight.
+- **Evergreen Light** (`oklch(69% 0.09 155)`): Dark theme variant. Same hue family, higher lightness. Passes WCAG AA on the dark background. Keeps the same character - green indicator light caught in warm lamplight.
 
-### Light palette — "Unbleached Paper"
+### Light palette - "Unbleached Paper"
 
 - **Unbleached** (`oklch(97.5% 0.007 80)`): Light background. Barely-warm off-white, like quality unbleached paper stock. Never pure white.
 - **Inkstone** (`oklch(17% 0.014 50)`): Light foreground. Warm near-black, green-tinted. Like quality printing ink. Warmer and darker than the previous carbon (#2c2c2c).
@@ -112,9 +112,9 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 - **Pith** (`oklch(92% 0.013 78)`): Popover and hover surfaces. The deepest light neutral.
 - **Sandstone** (`oklch(54% 0.012 65)`): Muted text. Dates, descriptions, metadata. Warm gray. Passes WCAG AA (≈4.7:1).
 - **Linen Edge** (`oklch(88% 0.015 74)`): Borders and dividers. Warm, visible, not harsh.
-- **Kiln Red** (`oklch(45% 0.22 18)`): Destructive / error states. Pure cardinal red — clearly distinguishable from Evergreen (hue 18° vs 155°).
+- **Kiln Red** (`oklch(45% 0.22 18)`): Destructive / error states. Pure cardinal red - clearly distinguishable from Evergreen (hue 18° vs 155°).
 
-### Dark palette — "Workshop at Night"
+### Dark palette - "Workshop at Night"
 
 - **Ironwood** (`oklch(13.5% 0.006 50)`): Dark background. Near-neutral with warm bias at hue 50. Low chroma avoids the reddish-brown cast of higher saturation, letting the green accent carry the room's color.
 - **Warm Off-White** (`oklch(93% 0.010 75)`): Dark foreground. Off-white with warmth.
@@ -126,39 +126,39 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 
 ### Named Rules
 
-**The Committed Strategy Rule.** Green carries 30–40% of the site's visual weight. It is not a token accent used once in the nav. Every identity surface and interactive state uses green. Diluting it defeats the system.
+**The Committed Strategy Rule.** Green carries 30-40% of the site's visual weight. It is not a token accent used once in the nav. Every identity surface and interactive state uses green. Diluting it defeats the system.
 
 **The Surface Boundary Rule.** Committed ≠ drenched. Page backgrounds and body text are never green. Green marks things you interact with or things that identify the site. The canvas stays warm neutral.
 
 **The No-Neutrals Rule.** Every color in the system has chroma ≥ 0.007. Pure black (#000) and pure white (#fff) are prohibited. Even the darkest dark and brightest light carry a perceptible tint.
 
-**The Same-Room Rule.** Both light and dark themes use the same warm-amber hue direction (H=50–80° in OKLCH). Neither theme is cool. The dark is not the opposite of the light — it's the same desk at a different hour.
+**The Same-Room Rule.** Both light and dark themes use the same warm-amber hue direction (H=50-80° in OKLCH). Neither theme is cool. The dark is not the opposite of the light - it's the same desk at a different hour.
 
 ## 3. Typography
 
-**Display Font:** Clash Display (Satoshi, system-ui, sans-serif fallback)
+**Display Font:** Space Grotesk (Satoshi, system-ui, sans-serif fallback)
 **Body Font:** Satoshi (system-ui, sans-serif fallback)
-**Label Font:** Clash Display (same as display; uppercase, wide tracking distinguishes labels from body)
+**Label Font:** Space Grotesk (same as display; uppercase, wide tracking distinguishes labels from body)
 
-**Character:** Two-family pairing from the same foundry (Indian Type Foundry / Fontshare). Clash Display is a bold grotesque with personality at large sizes — slightly quirky terminals and a confident stance that reads as deliberate, not decorated. Satoshi is a geometric sans with warmth in its terminals, handling body text and functional UI with clean readability. The pairing creates structural hierarchy through typeface contrast: identity surfaces (display, headlines, titles, labels) use Clash Display; content and utility (body, nav, meta, cards) use Satoshi. The two families share enough geometric DNA to feel cohesive, but differ enough at display sizes to create instant visual distinction.
+**Character:** Two-family pairing chosen for complementary contrast. Space Grotesk descends from Space Mono — it carries a technical, precision-tool character through distinctive terminals (the `a`, `g`, `r` are immediately recognizable) that read as deliberate craft at display sizes. It has a taller cap height relative to x-height than geometric sans defaults, giving it presence and vertical command at large sizes. Satoshi is a geometric sans with warmth in its terminals, handling body text and functional UI with clean readability. The pairing creates structural hierarchy through typeface contrast: identity surfaces (display, headlines, titles, labels) use Space Grotesk; content and utility (body, nav, meta, cards) use Satoshi. The two families share geometric foundations but differ clearly in character — one reads as engineering precision, the other as readable warmth.
 
 ### Hierarchy
 
-- **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero greeting, about page name. Clash Display. Single largest element. Negative tracking keeps it confident.
-- **Headline** (600, 1.5rem–2rem, line-height 1.3): Blog post titles, project detail titles. Clash Display.
-- **Title** (600, 1.5rem, line-height 1.4): Page titles on listing pages (Blog, Projects, Tags). Clash Display.
+- **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero greeting, about page name. Space Grotesk. Single largest element. Negative tracking keeps it confident.
+- **Headline** (600, 1.5rem–2rem, line-height 1.3): Blog post titles, project detail titles. Space Grotesk.
+- **Title** (600, 1.5rem, line-height 1.4): Page titles on listing pages (Blog, Projects, Tags). Space Grotesk.
 - **Body** (400, 1rem, line-height 1.625): All running content. Satoshi. Max 65–75ch line length.
-- **Label primary** (600, 0.875rem, letter-spacing 0.05em, uppercase): Section markers (“Background”, “Featured Projects”). Clash Display.
-- **Label secondary** (400, 0.875rem, sentence case): Descriptive sublabels (“How I got here”, “Things I'm building”). Satoshi. Softer voice beneath the label.
+- **Label primary** (600, 1.125rem, letter-spacing 0.05em, uppercase): Section markers ("Background", "Featured Projects"). Space Grotesk.
+- **Label secondary** (400, 0.875rem, sentence case): Descriptive sublabels ("How I got here", "Things I'm building"). Satoshi. Softer voice beneath the label.
 - **Card title** (600, 1.125rem): Blog and project card titles. Satoshi — cards are functional density, not identity.
 
 ### Named Rules
 
-**The Two-Family Rule.** Identity surfaces (display, headlines, page titles, labels) use Clash Display. Content surfaces (body, cards, nav, meta, breadcrumbs, tags) use Satoshi. The boundary is strict: if it announces identity or structure, it's Clash Display. If it's content to be read, it's Satoshi.
+**The Two-Family Rule.** Identity surfaces (display, headlines, page titles, labels) use Space Grotesk. Content surfaces (body, cards, nav, meta, breadcrumbs, tags) use Satoshi. The boundary is strict: if it announces identity or structure, it's Space Grotesk. If it's content to be read, it's Satoshi.
 
-**The Label Pair Rule.** Section labels are always two-layered: a Clash Display primary label (uppercase, tracked) and a Satoshi secondary line (sentence case, softer). The secondary line is the voice; the primary line is the structure. Both appear together.
+**The Label Pair Rule.** Section labels are always two-layered: a Space Grotesk primary label (uppercase, tracked, text-lg) and a Satoshi secondary line (sentence case, softer, text-sm). The secondary line is the voice; the primary line is the structure. Both appear together.
 
-**The Writing-First Rule.** Blog prose typography takes priority. Body line height (1.625) and line length (65–75ch) are tuned for long-form reading comfort. Everything else accommodates this.
+**The Writing-First Rule.** Blog prose typography takes priority. Body line height (1.625) and line length (65-75ch) are tuned for long-form reading comfort. Everything else accommodates this.
 
 ## 4. Elevation
 
@@ -168,7 +168,7 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 
 ### Named Rules
 
-**The Flat-By-Default Rule.** Static shadows prohibited. Elevation through tonal surface steps only. No shadows on hover — card interaction uses scale and tonal background wash only.
+**The Flat-By-Default Rule.** Static shadows prohibited. Elevation through tonal surface steps only. No shadows on hover - card interaction uses scale and tonal background wash only.
 
 ## 5. Components
 
@@ -205,12 +205,12 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 ### Do:
 
 - **Do** use green on identity markers (logo, accent rules, section bars), interactive states (card hover tonal shift, nav underlines, back links), prose links, tag pills, icon buttons, reading progress, TOC active headings. Green is the system's voice.
-- **Do** tint every neutral toward warmth (OKLCH hue 50–80°). No surface should feel cold.
+- **Do** tint every neutral toward warmth (OKLCH hue 50-80°). No surface should feel cold.
 - **Do** make hover states tangible. Cards scale and deepen with ease-out-quint easing. Nav links grow underlines. Arrows shift.
-- **Do** cap body text at 65–75ch. Reading comfort is non-negotiable.
+- **Do** cap body text at 65-75ch. Reading comfort is non-negotiable.
 - **Do** use tonal surface steps (Unbleached > Washi > Pith) instead of shadows for depth.
 - **Do** keep both light and dark themes warm. The dark is not the opposite of the light.
-- **Do** use Clash Display for identity surfaces (hero, page titles, section labels, detail titles) and Satoshi for content surfaces (body, cards, nav, meta). The boundary is identity vs content.
+- **Do** use Space Grotesk for identity surfaces (hero, page titles, section labels, detail titles) and Satoshi for content surfaces (body, cards, nav, meta). The boundary is identity vs content.
 - **Do** pair section labels with a secondary descriptive line in Satoshi (sentence case, softer).
 
 ### Don't:
@@ -220,9 +220,9 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 - **Don't** use side-stripe borders (border-left > 1px as accent). Blockquotes use a 2px left border; that's the one exception.
 - **Don't** use gradient text (background-clip: text with a gradient). Emphasis comes from weight or size.
 - **Don't** apply glassmorphism decoratively. All surfaces are opaque and tonal.
-- **Don't** add static shadows to any element. No shadows on hover either — scale and tonal wash only.
+- **Don't** add static shadows to any element. No shadows on hover either - scale and tonal wash only.
 - **Don't** use Evergreen as a large background fill or body text color. It marks identity and interaction, not surfaces.
 - **Don't** let the dark theme go cool. Ironwood (warm amber-shifted dark) is not negotiable.
 - **Don't** add 3D scenes, particle effects, scroll-jacking, or WebGL showcases. The craft shows in precision, not spectacle.
-- **Don't** use Clash Display for body text, card titles, or functional UI elements. It's an identity font, not a reading font.
-- **Don't** use Satoshi for page-level titles or section labels when Clash Display is available. The typographic contrast is the hierarchy.
+- **Don't** use Space Grotesk for body text, card titles, or functional UI elements. It's an identity font, not a reading font.
+- **Don't** use Satoshi for page-level titles or section labels when Space Grotesk is available. The typographic contrast is the hierarchy.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,23 +20,23 @@ colors:
   ember-red: "oklch(63% 0.22 20)"
 typography:
   display:
-    fontFamily: "Space Grotesk, Satoshi, system-ui, sans-serif"
+    fontFamily: "Bricolage Grotesque, Satoshi, system-ui, sans-serif"
     fontSize: "clamp(2.25rem, 6vw, 3.75rem)"
     fontWeight: 700
     lineHeight: 1.1
     letterSpacing: "-0.025em"
   headline:
-    fontFamily: "Space Grotesk, Satoshi, system-ui, sans-serif"
+    fontFamily: "Bricolage Grotesque, Satoshi, system-ui, sans-serif"
     fontSize: "1.5rem"
-    fontWeight: 600
+    fontWeight: 700
     lineHeight: 1.3
-    letterSpacing: "normal"
+    letterSpacing: "-0.015em"
   title:
-    fontFamily: "Space Grotesk, Satoshi, system-ui, sans-serif"
-    fontSize: "1.25rem"
-    fontWeight: 600
-    lineHeight: 1.4
-    letterSpacing: "normal"
+    fontFamily: "Bricolage Grotesque, Satoshi, system-ui, sans-serif"
+    fontSize: "1.875rem"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "-0.015em"
   body:
     fontFamily: "Satoshi, system-ui, sans-serif"
     fontSize: "1rem"
@@ -44,11 +44,11 @@ typography:
     lineHeight: 1.625
     letterSpacing: "normal"
   label:
-    fontFamily: "Space Grotesk, Satoshi, system-ui, sans-serif"
-    fontSize: "1.125rem"
-    fontWeight: 600
-    lineHeight: 1
-    letterSpacing: "0.05em"
+    fontFamily: "Bricolage Grotesque, Satoshi, system-ui, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "-0.015em"
 rounded:
   sm: "4px"
   md: "8px"
@@ -136,27 +136,26 @@ The palette uses warm neutrals paired with a deep evergreen accent. The green br
 
 ## 3. Typography
 
-**Display Font:** Space Grotesk (Satoshi, system-ui, sans-serif fallback)
+**Display Font:** Bricolage Grotesque (Satoshi, system-ui, sans-serif fallback)
 **Body Font:** Satoshi (system-ui, sans-serif fallback)
-**Label Font:** Space Grotesk (same as display; uppercase, wide tracking distinguishes labels from body)
+**Label Font:** Bricolage Grotesque (same as display; large bold title-case headings with trailing period distinguish section landmarks from body)
 
-**Character:** Two-family pairing chosen for complementary contrast. Space Grotesk descends from Space Mono — it carries a technical, precision-tool character through distinctive terminals (the `a`, `g`, `r` are immediately recognizable) that read as deliberate craft at display sizes. It has a taller cap height relative to x-height than geometric sans defaults, giving it presence and vertical command at large sizes. Satoshi is a geometric sans with warmth in its terminals, handling body text and functional UI with clean readability. The pairing creates structural hierarchy through typeface contrast: identity surfaces (display, headlines, titles, labels) use Space Grotesk; content and utility (body, nav, meta, cards) use Satoshi. The two families share geometric foundations but differ clearly in character — one reads as engineering precision, the other as readable warmth.
+**Character:** Two-family pairing chosen for genuine structural contrast. Bricolage Grotesque is a variable grotesque (weight 200–800, optical sizing 12–96) with origins in rough letterpress and industrial signage traditions. Where most geometric sans-serifs optimize for smooth, even strokes, Bricolage carries deliberate irregularity — slight ink traps, optically compensated junctions, letterforms that read as made rather than drawn. At display sizes with optical sizing maxed, it reads as a precision tool used with intent, which maps directly to this site's "craftsman's desk" identity. Satoshi is a refined, warm geometric sans that handles body text and functional UI with clean readability. The contrast is meaningful: Bricolage (rough, expressive, artisanal) for identity surfaces; Satoshi (polished, warm, readable) for content. The pairing tells the same story the color system does — intentional craft, not corporate uniformity.
 
 ### Hierarchy
 
-- **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero greeting, about page name. Space Grotesk. Single largest element. Negative tracking keeps it confident.
-- **Headline** (600, 1.5rem–2rem, line-height 1.3): Blog post titles, project detail titles. Space Grotesk.
-- **Title** (600, 1.5rem, line-height 1.4): Page titles on listing pages (Blog, Projects, Tags). Space Grotesk.
+- **Display** (700, clamp 2.25rem–3.75rem, line-height 1.1, tracking -0.025em): Hero greeting, about page name. Bricolage Grotesque. Single largest element. Negative tracking keeps it confident.
+- **Headline** (700, 1.875rem–2.25rem, line-height 1.2, tracking -0.015em): Page titles on listing pages (Blog., Projects.); about page and homepage section headings (Background., Projects., Writing.). Bricolage Grotesque. Trailing period is the personality marker.
+- **Title** (700, 1.5rem, line-height 1.3): Blog post titles, project detail titles. Bricolage Grotesque.
 - **Body** (400, 1rem, line-height 1.625): All running content. Satoshi. Max 65–75ch line length.
-- **Label primary** (600, 1.125rem, letter-spacing 0.05em, uppercase): Section markers ("Background", "Featured Projects"). Space Grotesk.
-- **Label secondary** (400, 0.875rem, sentence case): Descriptive sublabels ("How I got here", "Things I'm building"). Satoshi. Softer voice beneath the label.
+- **Section sublabel** (400, 0.875rem, sentence case): Descriptive line beneath section headings ("How I got here", "Things I'm building"). Satoshi. Muted. Softer voice beneath the heading.
 - **Card title** (600, 1.125rem): Blog and project card titles. Satoshi — cards are functional density, not identity.
 
 ### Named Rules
 
-**The Two-Family Rule.** Identity surfaces (display, headlines, page titles, labels) use Space Grotesk. Content surfaces (body, cards, nav, meta, breadcrumbs, tags) use Satoshi. The boundary is strict: if it announces identity or structure, it's Space Grotesk. If it's content to be read, it's Satoshi.
+**The Two-Family Rule.** Identity surfaces (display, headlines, page titles, section headings) use Bricolage Grotesque. Content surfaces (body, cards, nav, meta, breadcrumbs, tags) use Satoshi. The boundary is identity vs content.
 
-**The Label Pair Rule.** Section labels are always two-layered: a Space Grotesk primary label (uppercase, tracked, text-lg) and a Satoshi secondary line (sentence case, softer, text-sm). The secondary line is the voice; the primary line is the structure. Both appear together.
+**The Section Heading Rule.** Section landmarks are always two-layered: a Bricolage Grotesque heading (bold, tracking-tight, 1.5rem–1.875rem, Title Case, trailing period) and a Satoshi sublabel (sentence case, muted, text-sm). The period is the personality marker — it reads as deliberate and finished, not template-generated. Both appear together. The heading announces structure; the sublabel is the voice.
 
 **The Writing-First Rule.** Blog prose typography takes priority. Body line height (1.625) and line length (65-75ch) are tuned for long-form reading comfort. Everything else accommodates this.
 
@@ -210,7 +209,7 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 - **Do** cap body text at 65-75ch. Reading comfort is non-negotiable.
 - **Do** use tonal surface steps (Unbleached > Washi > Pith) instead of shadows for depth.
 - **Do** keep both light and dark themes warm. The dark is not the opposite of the light.
-- **Do** use Space Grotesk for identity surfaces (hero, page titles, section labels, detail titles) and Satoshi for content surfaces (body, cards, nav, meta). The boundary is identity vs content.
+- **Do** use Bricolage Grotesque for identity surfaces (hero, page titles, section headings, detail titles) and Satoshi for content surfaces (body, cards, nav, meta). The boundary is identity vs content.
 - **Do** pair section labels with a secondary descriptive line in Satoshi (sentence case, softer).
 
 ### Don't:
@@ -224,5 +223,5 @@ No shadows on any state. Card hover uses scale and tonal background wash only.
 - **Don't** use Evergreen as a large background fill or body text color. It marks identity and interaction, not surfaces.
 - **Don't** let the dark theme go cool. Ironwood (warm amber-shifted dark) is not negotiable.
 - **Don't** add 3D scenes, particle effects, scroll-jacking, or WebGL showcases. The craft shows in precision, not spectacle.
-- **Don't** use Space Grotesk for body text, card titles, or functional UI elements. It's an identity font, not a reading font.
-- **Don't** use Satoshi for page-level titles or section labels when Space Grotesk is available. The typographic contrast is the hierarchy.
+- **Don't** use Bricolage Grotesque for body text, card titles, or functional UI elements. It's an identity font, not a reading font.
+- **Don't** use Satoshi for page-level titles or section headings. The typographic contrast is the hierarchy.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,7 +16,6 @@ const currentYear = new Date().getFullYear();
           <span style="color: var(--color-warm);">&middot;</span>
           {SITE.author}
         </p>
-        <p class="text-xs text-muted-foreground/70">Built with Astro</p>
       </div>
     </div>
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,11 +10,14 @@ const currentYear = new Date().getFullYear();
     <div class="flex flex-col items-center gap-6">
       <SocialLinks class="items-center" />
 
-      <p class="text-sm text-muted-foreground">
-        &copy; {currentYear}
-        <span style="color: var(--color-warm);">&middot;</span>
-        {SITE.author}
-      </p>
+      <div class="flex flex-col items-center gap-1">
+        <p class="text-sm text-muted-foreground">
+          &copy; {currentYear}
+          <span style="color: var(--color-warm);">&middot;</span>
+          {SITE.author}
+        </p>
+        <p class="text-xs text-muted-foreground/70">Built with Astro</p>
+      </div>
     </div>
   </div>
 </footer>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -6,7 +6,9 @@ import { SITE } from "@/consts";
 <section class="pt-24 pb-14 md:pt-32 md:pb-18">
   <div class="flex flex-col gap-6">
     <div class="page-enter">
-      <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-foreground">
+      <h1
+        class="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-foreground font-display"
+      >
         {SITE.greeting}
       </h1>
       <div class="mt-3 h-px w-20" style="background-color: var(--color-warm);" aria-hidden="true">

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -18,25 +18,25 @@ const recentPosts = allPosts.slice(0, limit);
 {
   recentPosts.length > 0 && (
     <section class:list={cn("flex flex-col gap-y-4", className)}>
-      <div class="flex items-baseline justify-between">
-        <div class="flex flex-col gap-1">
-          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-            Writing
-          </h2>
+      <div class="flex flex-col gap-1">
+        <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+          Writing
+        </h2>
+        <div class="flex items-baseline justify-between">
           <p class="text-base text-muted-foreground">Things I've written</p>
+          <Link
+            href="/blog"
+            class="group inline-flex items-center gap-1.5 text-sm transition-colors"
+            style="color: var(--color-warm);"
+            prefetch="viewport"
+          >
+            View all
+            <Icon
+              name="fa6-solid:arrow-right"
+              class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5"
+            />
+          </Link>
         </div>
-        <Link
-          href="/blog"
-          class="group inline-flex items-center gap-1.5 text-sm transition-colors"
-          style="color: var(--color-warm);"
-          prefetch="viewport"
-        >
-          View all
-          <Icon
-            name="fa6-solid:arrow-right"
-            class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5"
-          />
-        </Link>
       </div>
 
       <div class="flex flex-col gap-4">

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -19,11 +19,11 @@ const recentPosts = allPosts.slice(0, limit);
   recentPosts.length > 0 && (
     <section class:list={cn("flex flex-col gap-y-4", className)}>
       <div class="flex items-center justify-between">
-        <div class="flex flex-col gap-0.5">
-          <span class="text-lg font-semibold uppercase tracking-wide text-muted-foreground font-display">
-            Recent Writing
-          </span>
-          <span class="text-sm text-muted-foreground">Things I've written</span>
+        <div class="flex flex-col gap-1">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+            Writing.
+          </h2>
+          <p class="text-sm text-muted-foreground">Things I've written</p>
         </div>
         <Link
           href="/blog"

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -18,12 +18,12 @@ const recentPosts = allPosts.slice(0, limit);
 {
   recentPosts.length > 0 && (
     <section class:list={cn("flex flex-col gap-y-4", className)}>
-      <div class="flex items-center justify-between">
+      <div class="flex items-baseline justify-between">
         <div class="flex flex-col gap-1">
           <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-            Writing.
+            Writing
           </h2>
-          <p class="text-sm text-muted-foreground">Things I've written</p>
+          <p class="text-base text-muted-foreground">Things I've written</p>
         </div>
         <Link
           href="/blog"

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -23,7 +23,7 @@ const recentPosts = allPosts.slice(0, limit);
           Writing
         </h2>
         <div class="flex items-baseline justify-between">
-          <p class="text-base text-muted-foreground">Things I've written</p>
+          <p class="text-base text-muted-foreground">Thoughts in public</p>
           <Link
             href="/blog"
             class="group inline-flex items-center gap-1.5 text-sm transition-colors"

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -20,10 +20,10 @@ const recentPosts = allPosts.slice(0, limit);
     <section class:list={cn("flex flex-col gap-y-4", className)}>
       <div class="flex items-center justify-between">
         <div class="flex flex-col gap-0.5">
-          <span class="text-sm font-semibold uppercase tracking-wide text-muted-foreground font-display">
+          <span class="text-lg font-semibold uppercase tracking-wide text-muted-foreground font-display">
             Recent Writing
           </span>
-          <span class="text-sm text-muted-foreground/75">Things I've written</span>
+          <span class="text-sm text-muted-foreground">Things I've written</span>
         </div>
         <Link
           href="/blog"

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -19,15 +19,11 @@ const recentPosts = allPosts.slice(0, limit);
   recentPosts.length > 0 && (
     <section class:list={cn("flex flex-col gap-y-4", className)}>
       <div class="flex items-center justify-between">
-        <div class="flex items-center gap-2.5">
-          <div
-            class="w-[3px] h-4 rounded-sm shrink-0"
-            style="background-color: var(--color-warm);"
-            aria-hidden="true"
-          />
-          <span class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
+        <div class="flex flex-col gap-0.5">
+          <span class="text-sm font-semibold uppercase tracking-wide text-muted-foreground font-display">
             Recent Writing
           </span>
+          <span class="text-sm text-muted-foreground/75">Things I've written</span>
         </div>
         <Link
           href="/blog"

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -38,13 +38,23 @@ export const SOCIAL_LINKS = {
 export const AUTHOR = {
   name: "Abijith S",
   fullName: "Abijith Suresh",
-  tagline: "Developer, builder, writer.",
+  tagline: "Backend engineer at UST. Kochi, Kerala.",
   avatar: "/avatar.jpg",
   twitterHandle: "@abijith_sh", // Kept for SEO compatibility (twitter:creator metadata)
 
   // About Page Content
   aboutNarrative:
-    "I'm Abijith, a software developer based in Kochi, India. I've been working professionally for about a year and a half, primarily with Java and Spring Boot on the backend side of things. I got into programming because I liked the idea of building things from scratch — what started as curiosity turned into a career, and I'm still figuring things out as I go. Along the way I've picked up React, Python, and TypeScript, though backend development is where I feel most at home.\n\nThis site is where I document my journey — the things I learn, the problems I solve, and occasional thoughts on tech and life. It's mostly for my future self, but if you find something useful here, that's a bonus.",
+    "Backend development suits me because the work lives in systems: how things connect, where load accumulates, what breaks in production that never showed in testing. Java and Spring Boot are the daily tools. The actual job is building things that hold up. I've been doing this professionally since 2024, mostly on backend services.\n\nThis site is where I write through problems. Notes on things I've built, things I've read, the occasional opinion. Writing is how I figure out what I actually think. If you find something useful here, good.",
+
+  // Work Experience (extensible timeline)
+  workExperience: [
+    {
+      company: "UST",
+      role: "Software Engineer",
+      period: "2024\u2013Present",
+      description: "Building and maintaining backend services with Java and Spring Boot.",
+    },
+  ],
 
   // Interests (for tag pills on about page)
   interests: ["Gaming", "Anime", "Reading", "Movies & TV"],

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -42,19 +42,15 @@ export const AUTHOR = {
   avatar: "/avatar.jpg",
   twitterHandle: "@abijith_sh", // Kept for SEO compatibility (twitter:creator metadata)
 
-  // About Page Content
-  aboutNarrative:
-    "Backend development suits me because the work lives in systems: how things connect, where load accumulates, what breaks in production that never showed in testing. Java and Spring Boot are the daily tools. The actual job is building things that hold up. I've been doing this professionally since 2024, mostly on backend services.\n\nThis site is where I write through problems. Notes on things I've built, things I've read, the occasional opinion. Writing is how I figure out what I actually think. If you find something useful here, good.",
+  // About Page — three narrative sections
+  aboutWhatIDo:
+    "I work as a software engineer at UST, based in Kochi. Most of the work is backend: Java, Spring Boot, services that sit between data and the rest of the system. The actual job is reliability: thinking through failure modes, handling load, accounting for cases that don't show up in the happy path. I've been working on this since 2024.",
 
-  // Work Experience (extensible timeline)
-  workExperience: [
-    {
-      company: "UST",
-      role: "Software Engineer",
-      period: "2024\u2013Present",
-      description: "Building and maintaining backend services with Java and Spring Boot.",
-    },
-  ],
+  aboutHowIGotHere:
+    "The path was mostly curiosity. Tried things, broke them, worked out why. Java and Spring Boot came through professional work; Python, TypeScript, and enough React to trace a problem from the database to the browser came from not wanting to stop at a service boundary. Backend is where I've settled because the problems there are the ones I keep thinking about.",
+
+  aboutThisSite:
+    "Writing is how I understand what I actually think about something. This site is where that ends up: notes after shipping things, thoughts after reading, the occasional opinion. No particular theme except that it's mine.",
 
   // Interests (for tag pills on about page)
   interests: ["Gaming", "Anime", "Reading", "Movies & TV"],

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -12,7 +12,7 @@ export const SITE = {
   greeting: "Hey, I'm Abijith",
   role: "Backend Engineer",
   heroIntro:
-    "Backend engineer in Kochi building things with Java and Spring Boot.\nI'm still figuring things out as I go.",
+    "Based in Kochi, Kerala. I work on the backend, the part that keeps things running while everything else stays visible. Java and Spring Boot, mostly.",
 
   // Pagination
   postsPerPage: 10,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -39,7 +39,7 @@ const {
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&display=swap"
       rel="stylesheet"
     />
     <link rel="preconnect" href="https://api.fontshare.com" crossorigin />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,9 +36,15 @@ const {
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="preconnect" href="https://api.fontshare.com" crossorigin />
     <link
-      href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,600,700&f[]=clash-display@400,500,600,700&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,600,700&display=swap"
       rel="stylesheet"
     />
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -38,7 +38,7 @@ const {
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://api.fontshare.com" crossorigin />
     <link
-      href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,600,700&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,600,700&f[]=clash-display@400,500,600,700&display=swap"
       rel="stylesheet"
     />
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -23,7 +23,7 @@ import { Icon } from "astro-icon/components";
       </div>
 
       <div class="flex flex-col items-center gap-y-3 text-center">
-        <h1 class="text-3xl font-semibold text-foreground">Page Not Found</h1>
+        <h1 class="text-3xl font-semibold text-foreground font-display">Page Not Found</h1>
         <p class="text-lg text-muted-foreground max-w-md">
           The page you're looking for doesn't exist or has been moved.
         </p>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -12,7 +12,7 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
   type="profile"
   jsonLd={{ type: "person" }}
 >
-  <div class="w-full mx-auto flex grow flex-col gap-y-10 px-4 max-w-3xl pb-12 page-enter">
+  <div class="w-full mx-auto flex grow flex-col gap-y-12 px-4 max-w-3xl pb-12 page-enter">
     <Breadcrumb
       items={[
         { label: "Home", href: "/", icon: "home" },
@@ -20,58 +20,52 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
       ]}
     />
 
-    <!-- Centered identity block -->
-    <header class="flex flex-col items-center text-center gap-4 page-enter page-enter-delay-1">
+    <!-- Identity header: avatar + name side by side -->
+    <header class="flex items-center gap-6 page-enter page-enter-delay-1">
       <img
         src={AUTHOR.avatar}
         alt={AUTHOR.name}
-        class="w-36 h-36 sm:w-44 sm:h-44 rounded-full object-cover ring-2 ring-border"
+        class="w-20 h-20 sm:w-28 sm:h-28 rounded-full object-cover ring-2 ring-border flex-shrink-0"
       />
       <div>
         <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
           {AUTHOR.fullName}
         </h1>
-        <p class="mt-1.5 text-muted-foreground text-sm">{AUTHOR.tagline}</p>
+        <p class="mt-1.5 text-muted-foreground">{AUTHOR.tagline}</p>
       </div>
     </header>
 
     <!-- Content sections -->
-    <div class="mx-auto max-w-2xl w-full flex flex-col gap-10">
+    <div class="flex flex-col gap-12">
       <!-- Section: Background -->
-      <section class="flex flex-col gap-3 page-enter page-enter-delay-2">
-        <div class="flex flex-col gap-0.5">
-          <h2
-            class="text-lg font-semibold uppercase tracking-wide text-muted-foreground font-display"
-          >
-            Background
+      <section class="flex flex-col gap-4 page-enter page-enter-delay-2">
+        <div class="flex flex-col gap-1">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+            Background.
           </h2>
           <p class="text-sm text-muted-foreground">How I got here</p>
         </div>
-        <p class="text-foreground leading-relaxed">{paragraphs[0]}</p>
+        <p class="max-w-2xl text-foreground leading-relaxed">{paragraphs[0]}</p>
       </section>
 
       <!-- Section: This site -->
-      <section class="flex flex-col gap-3 page-enter page-enter-delay-3">
-        <div class="flex flex-col gap-0.5">
-          <h2
-            class="text-lg font-semibold uppercase tracking-wide text-muted-foreground font-display"
-          >
-            This Site
+      <section class="flex flex-col gap-4 page-enter page-enter-delay-3">
+        <div class="flex flex-col gap-1">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+            This site.
           </h2>
           <p class="text-sm text-muted-foreground">What this corner of the internet is for</p>
         </div>
-        <p class="text-foreground leading-relaxed">{paragraphs[1]}</p>
+        <p class="max-w-2xl text-foreground leading-relaxed">{paragraphs[1]}</p>
       </section>
 
       <!-- Interests -->
       <aside class="page-enter page-enter-delay-3">
-        <div class="h-px w-full mb-8 bg-border" aria-hidden="true"></div>
-        <div class="flex flex-col gap-1">
-          <div class="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-4">
-            <h2
-              class="text-lg font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap font-display"
-            >
-              Away from the Keyboard
+        <div class="h-px w-full mb-10 bg-border" aria-hidden="true"></div>
+        <div class="flex flex-col gap-4">
+          <div class="flex flex-col gap-1">
+            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+              Away from the keyboard.
             </h2>
             <span class="text-sm text-muted-foreground">When I'm not coding</span>
           </div>
@@ -79,7 +73,7 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
             {
               AUTHOR.interests.map((interest, i) => (
                 <>
-                  <span class="text-sm text-foreground">{interest}</span>
+                  <span class="text-foreground">{interest}</span>
                   {i < AUTHOR.interests.length - 1 && (
                     <span class="mx-1 font-light opacity-60" style="color: var(--color-warm);">
                       /

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -41,9 +41,9 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
       <section class="flex flex-col gap-4 page-enter page-enter-delay-2">
         <div class="flex flex-col gap-1">
           <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-            Background.
+            Background
           </h2>
-          <p class="text-sm text-muted-foreground">How I got here</p>
+          <p class="text-base text-muted-foreground">How I got here</p>
         </div>
         <p class="max-w-2xl text-foreground leading-relaxed">{paragraphs[0]}</p>
       </section>
@@ -52,9 +52,9 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
       <section class="flex flex-col gap-4 page-enter page-enter-delay-3">
         <div class="flex flex-col gap-1">
           <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-            This site.
+            This site
           </h2>
-          <p class="text-sm text-muted-foreground">What this corner of the internet is for</p>
+          <p class="text-base text-muted-foreground">What this corner of the internet is for</p>
         </div>
         <p class="max-w-2xl text-foreground leading-relaxed">{paragraphs[1]}</p>
       </section>
@@ -65,9 +65,9 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
         <div class="flex flex-col gap-4">
           <div class="flex flex-col gap-1">
             <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-              Away from the keyboard.
+              Away from the keyboard
             </h2>
-            <span class="text-sm text-muted-foreground">When I'm not coding</span>
+            <span class="text-base text-muted-foreground">When I'm not coding</span>
           </div>
           <span class="flex flex-wrap items-baseline gap-1">
             {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,8 +2,6 @@
 import Breadcrumb from "@/components/Breadcrumb.astro";
 import { AUTHOR, SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
-
-const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
 ---
 
 <Layout
@@ -35,73 +33,62 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
       </div>
     </header>
 
-    <!-- Content sections -->
+    <!-- Narrative sections -->
     <div class="flex flex-col gap-12">
-      <!-- Section: Experience -->
+      <!-- Section: What I do -->
       <section class="flex flex-col gap-4 page-enter page-enter-delay-2">
         <div class="flex flex-col gap-1">
           <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-            Experience
+            What I do
           </h2>
-          <p class="text-base text-muted-foreground">Where I've worked</p>
+          <p class="text-base text-muted-foreground">The day job</p>
         </div>
-        <ul class="flex flex-col gap-6">
-          {
-            AUTHOR.workExperience.map((job) => (
-              <li class="flex flex-col sm:grid sm:grid-cols-[8rem_1fr] gap-1 sm:gap-x-6">
-                <span class="text-sm text-muted-foreground tabular-nums sm:pt-0.5">
-                  {job.period}
-                </span>
-                <div class="flex flex-col gap-0.5">
-                  <span class="font-medium text-foreground">{job.role}</span>
-                  <span class="text-sm text-muted-foreground">{job.company}</span>
-                  <p class="text-sm text-muted-foreground leading-relaxed mt-1">
-                    {job.description}
-                  </p>
-                </div>
-              </li>
-            ))
-          }
-        </ul>
+        <p class="max-w-2xl text-foreground leading-relaxed">{AUTHOR.aboutWhatIDo}</p>
       </section>
 
-      <!-- Section: Background -->
+      <!-- Section: How I got here -->
       <section class="flex flex-col gap-4 page-enter page-enter-delay-3">
         <div class="flex flex-col gap-1">
           <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-            Background
+            How I got here
           </h2>
-          <p class="text-base text-muted-foreground">The short version</p>
+          <p class="text-base text-muted-foreground">The path</p>
         </div>
-        <div class="flex flex-col gap-4 max-w-2xl">
-          {paragraphs.map((p) => <p class="text-foreground leading-relaxed">{p}</p>)}
+        <p class="max-w-2xl text-foreground leading-relaxed">{AUTHOR.aboutHowIGotHere}</p>
+      </section>
+
+      <!-- Section: This site -->
+      <section class="flex flex-col gap-4 page-enter page-enter-delay-3">
+        <div class="flex flex-col gap-1">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+            This site
+          </h2>
+          <p class="text-base text-muted-foreground">Why it exists</p>
         </div>
+        <p class="max-w-2xl text-foreground leading-relaxed">{AUTHOR.aboutThisSite}</p>
       </section>
 
       <!-- Section: Away from the keyboard -->
-      <aside class="page-enter page-enter-delay-3">
-        <div class="h-px w-full mb-10 bg-border" aria-hidden="true"></div>
-        <div class="flex flex-col gap-4">
-          <div class="flex flex-col gap-1">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-              Away from the keyboard
-            </h2>
-            <span class="text-base text-muted-foreground">When I'm not coding</span>
-          </div>
-          <div class="flex flex-wrap gap-2">
-            {
-              AUTHOR.interests.map((interest) => (
-                <span
-                  class="text-xs px-3 py-1.5 rounded-md font-medium"
-                  style="background: var(--color-warm-muted); color: var(--color-warm);"
-                >
-                  {interest}
-                </span>
-              ))
-            }
-          </div>
+      <section class="flex flex-col gap-4 page-enter page-enter-delay-3">
+        <div class="flex flex-col gap-1">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+            Away from the keyboard
+          </h2>
+          <p class="text-base text-muted-foreground">When I'm not coding</p>
         </div>
-      </aside>
+        <div class="flex flex-wrap gap-2">
+          {
+            AUTHOR.interests.map((interest) => (
+              <span
+                class="text-xs px-3 py-1.5 rounded-md font-medium"
+                style="background: var(--color-warm-muted); color: var(--color-warm);"
+              >
+                {interest}
+              </span>
+            ))
+          }
+        </div>
+      </section>
     </div>
   </div>
 </Layout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,7 +28,7 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
         class="w-20 h-20 sm:w-28 sm:h-28 rounded-full object-cover ring-2 ring-border flex-shrink-0"
       />
       <div>
-        <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
+        <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-foreground font-display">
           {AUTHOR.fullName}
         </h1>
         <p class="mt-1.5 text-muted-foreground">{AUTHOR.tagline}</p>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -37,29 +37,48 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
 
     <!-- Content sections -->
     <div class="flex flex-col gap-12">
-      <!-- Section: Background -->
+      <!-- Section: Experience -->
       <section class="flex flex-col gap-4 page-enter page-enter-delay-2">
+        <div class="flex flex-col gap-1">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+            Experience
+          </h2>
+          <p class="text-base text-muted-foreground">Where I've worked</p>
+        </div>
+        <ul class="flex flex-col gap-6">
+          {
+            AUTHOR.workExperience.map((job) => (
+              <li class="flex flex-col sm:grid sm:grid-cols-[8rem_1fr] gap-1 sm:gap-x-6">
+                <span class="text-sm text-muted-foreground tabular-nums sm:pt-0.5">
+                  {job.period}
+                </span>
+                <div class="flex flex-col gap-0.5">
+                  <span class="font-medium text-foreground">{job.role}</span>
+                  <span class="text-sm text-muted-foreground">{job.company}</span>
+                  <p class="text-sm text-muted-foreground leading-relaxed mt-1">
+                    {job.description}
+                  </p>
+                </div>
+              </li>
+            ))
+          }
+        </ul>
+      </section>
+
+      <!-- Section: Background -->
+      <section class="flex flex-col gap-4 page-enter page-enter-delay-3">
         <div class="flex flex-col gap-1">
           <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
             Background
           </h2>
-          <p class="text-base text-muted-foreground">How I got here</p>
+          <p class="text-base text-muted-foreground">The short version</p>
         </div>
-        <p class="max-w-2xl text-foreground leading-relaxed">{paragraphs[0]}</p>
+        <div class="flex flex-col gap-4 max-w-2xl">
+          {paragraphs.map((p) => <p class="text-foreground leading-relaxed">{p}</p>)}
+        </div>
       </section>
 
-      <!-- Section: This site -->
-      <section class="flex flex-col gap-4 page-enter page-enter-delay-3">
-        <div class="flex flex-col gap-1">
-          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-            This site
-          </h2>
-          <p class="text-base text-muted-foreground">What this corner of the internet is for</p>
-        </div>
-        <p class="max-w-2xl text-foreground leading-relaxed">{paragraphs[1]}</p>
-      </section>
-
-      <!-- Interests -->
+      <!-- Section: Away from the keyboard -->
       <aside class="page-enter page-enter-delay-3">
         <div class="h-px w-full mb-10 bg-border" aria-hidden="true"></div>
         <div class="flex flex-col gap-4">
@@ -69,20 +88,18 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
             </h2>
             <span class="text-base text-muted-foreground">When I'm not coding</span>
           </div>
-          <span class="flex flex-wrap items-baseline gap-1">
+          <div class="flex flex-wrap gap-2">
             {
-              AUTHOR.interests.map((interest, i) => (
-                <>
-                  <span class="text-foreground">{interest}</span>
-                  {i < AUTHOR.interests.length - 1 && (
-                    <span class="mx-1 font-light opacity-60" style="color: var(--color-warm);">
-                      /
-                    </span>
-                  )}
-                </>
+              AUTHOR.interests.map((interest) => (
+                <span
+                  class="text-xs px-3 py-1.5 rounded-md font-medium"
+                  style="background: var(--color-warm-muted); color: var(--color-warm);"
+                >
+                  {interest}
+                </span>
               ))
             }
-          </span>
+          </div>
         </div>
       </aside>
     </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -41,11 +41,11 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
       <section class="flex flex-col gap-3 page-enter page-enter-delay-2">
         <div class="flex flex-col gap-0.5">
           <h2
-            class="text-sm font-semibold uppercase tracking-wide text-muted-foreground font-display"
+            class="text-lg font-semibold uppercase tracking-wide text-muted-foreground font-display"
           >
             Background
           </h2>
-          <p class="text-sm text-muted-foreground/75">How I got here</p>
+          <p class="text-sm text-muted-foreground">How I got here</p>
         </div>
         <p class="text-foreground leading-relaxed">{paragraphs[0]}</p>
       </section>
@@ -54,11 +54,11 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
       <section class="flex flex-col gap-3 page-enter page-enter-delay-3">
         <div class="flex flex-col gap-0.5">
           <h2
-            class="text-sm font-semibold uppercase tracking-wide text-muted-foreground font-display"
+            class="text-lg font-semibold uppercase tracking-wide text-muted-foreground font-display"
           >
             This Site
           </h2>
-          <p class="text-sm text-muted-foreground/75">What this corner of the internet is for</p>
+          <p class="text-sm text-muted-foreground">What this corner of the internet is for</p>
         </div>
         <p class="text-foreground leading-relaxed">{paragraphs[1]}</p>
       </section>
@@ -69,11 +69,11 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
         <div class="flex flex-col gap-1">
           <div class="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-4">
             <h2
-              class="text-sm font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap font-display"
+              class="text-lg font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap font-display"
             >
               Away from the Keyboard
             </h2>
-            <span class="text-sm text-muted-foreground/75">When I'm not coding</span>
+            <span class="text-sm text-muted-foreground">When I'm not coding</span>
           </div>
           <span class="flex flex-wrap items-baseline gap-1">
             {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -39,34 +39,18 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
     <div class="mx-auto max-w-2xl w-full flex flex-col gap-10">
       <!-- Section: Background -->
       <section class="flex flex-col gap-3 page-enter page-enter-delay-2">
-        <div class="flex items-center gap-2.5">
-          <div
-            class="w-[3px] h-4 rounded-sm shrink-0"
-            style="background-color: var(--color-warm);"
-            aria-hidden="true"
-          >
-          </div>
-          <h2 class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
-            Background
-          </h2>
-        </div>
-        <p class="text-foreground/80 leading-relaxed">{paragraphs[0]}</p>
+        <h2 class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
+          Background
+        </h2>
+        <p class="text-foreground leading-relaxed">{paragraphs[0]}</p>
       </section>
 
       <!-- Section: This site -->
       <section class="flex flex-col gap-3 page-enter page-enter-delay-3">
-        <div class="flex items-center gap-2.5">
-          <div
-            class="w-[3px] h-4 rounded-sm shrink-0"
-            style="background-color: var(--color-warm);"
-            aria-hidden="true"
-          >
-          </div>
-          <h2 class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
-            This site
-          </h2>
-        </div>
-        <p class="text-foreground/80 leading-relaxed">{paragraphs[1]}</p>
+        <h2 class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
+          This site
+        </h2>
+        <p class="text-foreground leading-relaxed">{paragraphs[1]}</p>
       </section>
 
       <!-- Interests -->
@@ -82,7 +66,7 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
             {
               AUTHOR.interests.map((interest, i) => (
                 <>
-                  <span class="text-sm text-foreground/70">{interest}</span>
+                  <span class="text-sm text-foreground">{interest}</span>
                   {i < AUTHOR.interests.length - 1 && (
                     <span class="mx-1 font-light opacity-60" style="color: var(--color-warm);">
                       /

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,7 +28,7 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
         class="w-36 h-36 sm:w-44 sm:h-44 rounded-full object-cover ring-2 ring-border"
       />
       <div>
-        <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground">
+        <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
           {AUTHOR.fullName}
         </h1>
         <p class="mt-1.5 text-muted-foreground text-sm">{AUTHOR.tagline}</p>
@@ -39,29 +39,42 @@ const paragraphs = AUTHOR.aboutNarrative.split("\n\n");
     <div class="mx-auto max-w-2xl w-full flex flex-col gap-10">
       <!-- Section: Background -->
       <section class="flex flex-col gap-3 page-enter page-enter-delay-2">
-        <h2 class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
-          Background
-        </h2>
+        <div class="flex flex-col gap-0.5">
+          <h2
+            class="text-sm font-semibold uppercase tracking-wide text-muted-foreground font-display"
+          >
+            Background
+          </h2>
+          <p class="text-sm text-muted-foreground/75">How I got here</p>
+        </div>
         <p class="text-foreground leading-relaxed">{paragraphs[0]}</p>
       </section>
 
       <!-- Section: This site -->
       <section class="flex flex-col gap-3 page-enter page-enter-delay-3">
-        <h2 class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
-          This site
-        </h2>
+        <div class="flex flex-col gap-0.5">
+          <h2
+            class="text-sm font-semibold uppercase tracking-wide text-muted-foreground font-display"
+          >
+            This Site
+          </h2>
+          <p class="text-sm text-muted-foreground/75">What this corner of the internet is for</p>
+        </div>
         <p class="text-foreground leading-relaxed">{paragraphs[1]}</p>
       </section>
 
       <!-- Interests -->
       <aside class="page-enter page-enter-delay-3">
         <div class="h-px w-full mb-8 bg-border" aria-hidden="true"></div>
-        <div class="flex flex-col gap-2.5 sm:flex-row sm:items-baseline sm:gap-4">
-          <span
-            class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap"
-          >
-            Away from the keyboard
-          </span>
+        <div class="flex flex-col gap-1">
+          <div class="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-4">
+            <h2
+              class="text-sm font-semibold uppercase tracking-wide text-muted-foreground whitespace-nowrap font-display"
+            >
+              Away from the Keyboard
+            </h2>
+            <span class="text-sm text-muted-foreground/75">When I'm not coding</span>
+          </div>
           <span class="flex flex-wrap items-baseline gap-1">
             {
               AUTHOR.interests.map((interest, i) => (

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -76,9 +76,9 @@ const postsByYear = groupByYear(posts, (post) => post.data.publishDate);
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
       <div class="flex flex-col gap-1">
         <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
-          Blog.
+          Blog
         </h1>
-        <p class="text-sm text-muted-foreground">Articles, tutorials, and thoughts</p>
+        <p class="text-base text-muted-foreground">Articles, tutorials, and thoughts</p>
       </div>
     </div>
 

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -78,7 +78,7 @@ const postsByYear = groupByYear(posts, (post) => post.data.publishDate);
         <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
           Blog
         </h1>
-        <p class="text-base text-muted-foreground">Articles, tutorials, and thoughts</p>
+        <p class="text-base text-muted-foreground">Notes, write-ups, and the occasional opinion</p>
       </div>
     </div>
 

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -76,7 +76,7 @@ const postsByYear = groupByYear(posts, (post) => post.data.publishDate);
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
       <div class="flex flex-col gap-0.5">
         <h1 class="text-3xl font-semibold text-foreground font-display">Blog</h1>
-        <p class="text-sm text-muted-foreground/75">Articles, tutorials, and thoughts</p>
+        <p class="text-sm text-muted-foreground">Articles, tutorials, and thoughts</p>
       </div>
     </div>
 

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -74,10 +74,10 @@ const postsByYear = groupByYear(posts, (post) => post.data.publishDate);
     </div>
 
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
-      <h1 class="text-3xl font-semibold text-foreground">Blog</h1>
-      <p class="text-muted-foreground">
-        Articles, tutorials, and thoughts on web development, design, and technology.
-      </p>
+      <div class="flex flex-col gap-0.5">
+        <h1 class="text-3xl font-semibold text-foreground font-display">Blog</h1>
+        <p class="text-sm text-muted-foreground/75">Articles, tutorials, and thoughts</p>
+      </div>
     </div>
 
     {

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -74,8 +74,10 @@ const postsByYear = groupByYear(posts, (post) => post.data.publishDate);
     </div>
 
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
-      <div class="flex flex-col gap-0.5">
-        <h1 class="text-3xl font-semibold text-foreground font-display">Blog</h1>
+      <div class="flex flex-col gap-1">
+        <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
+          Blog.
+        </h1>
         <p class="text-sm text-muted-foreground">Articles, tutorials, and thoughts</p>
       </div>
     </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -75,7 +75,7 @@ const relatedPosts = await getRelatedPosts(post.id, 3);
     </div>
 
     <header class="col-start-2 flex flex-col gap-y-4 px-4 page-enter page-enter-delay-2">
-      <h1 class="text-3xl sm:text-4xl font-semibold text-foreground">{title}</h1>
+      <h1 class="text-3xl sm:text-4xl font-semibold text-foreground font-display">{title}</h1>
 
       <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
         <time datetime={publishDate.toISOString()}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,25 +28,25 @@ const hasProjects = allProjects.length > 0;
       hasProjects && (
         <section class="py-8 border-t border-border/50 page-enter page-enter-delay-1">
           <div class="flex flex-col gap-y-4">
-            <div class="flex items-baseline justify-between">
-              <div class="flex flex-col gap-1">
-                <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-                  Projects
-                </h2>
+            <div class="flex flex-col gap-1">
+              <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+                Projects
+              </h2>
+              <div class="flex items-baseline justify-between">
                 <p class="text-base text-muted-foreground">Things I'm building</p>
+                <Link
+                  href="/projects"
+                  class="group inline-flex items-center gap-1.5 text-sm transition-colors"
+                  style="color: var(--color-warm);"
+                  prefetch="viewport"
+                >
+                  View all
+                  <Icon
+                    name="fa6-solid:arrow-right"
+                    class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5"
+                  />
+                </Link>
               </div>
-              <Link
-                href="/projects"
-                class="group inline-flex items-center gap-1.5 text-sm transition-colors"
-                style="color: var(--color-warm);"
-                prefetch="viewport"
-              >
-                View all
-                <Icon
-                  name="fa6-solid:arrow-right"
-                  class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5"
-                />
-              </Link>
             </div>
 
             <div class="flex flex-col gap-4">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,15 +29,11 @@ const hasProjects = allProjects.length > 0;
         <section class="py-8 border-t border-border/50 page-enter page-enter-delay-1">
           <div class="flex flex-col gap-y-4">
             <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2.5">
-                <div
-                  class="w-[3px] h-4 rounded-sm shrink-0"
-                  style="background-color: var(--color-warm);"
-                  aria-hidden="true"
-                />
-                <span class="text-[0.8125rem] font-semibold uppercase tracking-wide text-muted-foreground">
+              <div class="flex flex-col gap-0.5">
+                <span class="text-sm font-semibold uppercase tracking-wide text-muted-foreground font-display">
                   Featured Projects
                 </span>
+                <span class="text-sm text-muted-foreground/75">Things I'm building</span>
               </div>
               <Link
                 href="/projects"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,7 +33,7 @@ const hasProjects = allProjects.length > 0;
                 Projects
               </h2>
               <div class="flex items-baseline justify-between">
-                <p class="text-base text-muted-foreground">Things I'm building</p>
+                <p class="text-base text-muted-foreground">What I've built</p>
                 <Link
                   href="/projects"
                   class="group inline-flex items-center gap-1.5 text-sm transition-colors"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,12 +28,12 @@ const hasProjects = allProjects.length > 0;
       hasProjects && (
         <section class="py-8 border-t border-border/50 page-enter page-enter-delay-1">
           <div class="flex flex-col gap-y-4">
-            <div class="flex items-center justify-between">
+            <div class="flex items-baseline justify-between">
               <div class="flex flex-col gap-1">
                 <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
-                  Projects.
+                  Projects
                 </h2>
-                <p class="text-sm text-muted-foreground">Things I'm building</p>
+                <p class="text-base text-muted-foreground">Things I'm building</p>
               </div>
               <Link
                 href="/projects"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,11 +29,11 @@ const hasProjects = allProjects.length > 0;
         <section class="py-8 border-t border-border/50 page-enter page-enter-delay-1">
           <div class="flex flex-col gap-y-4">
             <div class="flex items-center justify-between">
-              <div class="flex flex-col gap-0.5">
-                <span class="text-lg font-semibold uppercase tracking-wide text-muted-foreground font-display">
-                  Featured Projects
-                </span>
-                <span class="text-sm text-muted-foreground">Things I'm building</span>
+              <div class="flex flex-col gap-1">
+                <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-foreground font-display">
+                  Projects.
+                </h2>
+                <p class="text-sm text-muted-foreground">Things I'm building</p>
               </div>
               <Link
                 href="/projects"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,10 +30,10 @@ const hasProjects = allProjects.length > 0;
           <div class="flex flex-col gap-y-4">
             <div class="flex items-center justify-between">
               <div class="flex flex-col gap-0.5">
-                <span class="text-sm font-semibold uppercase tracking-wide text-muted-foreground font-display">
+                <span class="text-lg font-semibold uppercase tracking-wide text-muted-foreground font-display">
                   Featured Projects
                 </span>
-                <span class="text-sm text-muted-foreground/75">Things I'm building</span>
+                <span class="text-sm text-muted-foreground">Things I'm building</span>
               </div>
               <Link
                 href="/projects"

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -78,7 +78,7 @@ const projectsByYear = groupByYear(projects, (project) => project.data.date);
         <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
           Projects
         </h1>
-        <p class="text-base text-muted-foreground">Things I've built and shipped</p>
+        <p class="text-base text-muted-foreground">Shipped work, side projects, and experiments</p>
       </div>
     </div>
 

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -76,9 +76,9 @@ const projectsByYear = groupByYear(projects, (project) => project.data.date);
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
       <div class="flex flex-col gap-1">
         <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
-          Projects.
+          Projects
         </h1>
-        <p class="text-sm text-muted-foreground">Things I've built and shipped</p>
+        <p class="text-base text-muted-foreground">Things I've built and shipped</p>
       </div>
     </div>
 

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -76,7 +76,7 @@ const projectsByYear = groupByYear(projects, (project) => project.data.date);
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
       <div class="flex flex-col gap-0.5">
         <h1 class="text-3xl font-semibold text-foreground font-display">Projects</h1>
-        <p class="text-sm text-muted-foreground/75">Things I've built and shipped</p>
+        <p class="text-sm text-muted-foreground">Things I've built and shipped</p>
       </div>
     </div>
 

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -74,8 +74,10 @@ const projectsByYear = groupByYear(projects, (project) => project.data.date);
     </div>
 
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
-      <div class="flex flex-col gap-0.5">
-        <h1 class="text-3xl font-semibold text-foreground font-display">Projects</h1>
+      <div class="flex flex-col gap-1">
+        <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
+          Projects.
+        </h1>
         <p class="text-sm text-muted-foreground">Things I've built and shipped</p>
       </div>
     </div>

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -74,10 +74,10 @@ const projectsByYear = groupByYear(projects, (project) => project.data.date);
     </div>
 
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
-      <h1 class="text-3xl font-semibold text-foreground">Projects</h1>
-      <p class="text-muted-foreground">
-        A collection of projects I've built, ranging from web applications to CLI tools.
-      </p>
+      <div class="flex flex-col gap-0.5">
+        <h1 class="text-3xl font-semibold text-foreground font-display">Projects</h1>
+        <p class="text-sm text-muted-foreground/75">Things I've built and shipped</p>
+      </div>
     </div>
 
     {

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -40,7 +40,7 @@ const formattedDate = formatBlogDate(date);
 
     <article class="flex flex-col gap-y-6 page-enter page-enter-delay-2">
       <header class="flex flex-col gap-y-4">
-        <h1 class="text-3xl sm:text-4xl font-semibold text-foreground">{title}</h1>
+        <h1 class="text-3xl sm:text-4xl font-semibold text-foreground font-display">{title}</h1>
 
         <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
           <time datetime={date.toISOString()}>{formattedDate}</time>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -121,7 +121,7 @@ const contentByYear = groupByYear(allContent, (item) => item.date);
       <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
         {tagLabel}
       </h1>
-      <p class="text-sm text-muted-foreground">
+      <p class="text-base text-muted-foreground">
         {totalCount}
         {totalCount === 1 ? "item" : "items"}
         {

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -118,7 +118,9 @@ const contentByYear = groupByYear(allContent, (item) => item.date);
     </div>
 
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
-      <h1 class="text-3xl font-semibold text-foreground font-display">{tagLabel}</h1>
+      <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
+        {tagLabel}
+      </h1>
       <p class="text-sm text-muted-foreground">
         {totalCount}
         {totalCount === 1 ? "item" : "items"}

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -118,7 +118,7 @@ const contentByYear = groupByYear(allContent, (item) => item.date);
     </div>
 
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
-      <h1 class="text-3xl font-semibold text-foreground">{tagLabel}</h1>
+      <h1 class="text-3xl font-semibold text-foreground font-display">{tagLabel}</h1>
       <p class="text-sm text-muted-foreground">
         {totalCount}
         {totalCount === 1 ? "item" : "items"}

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -24,7 +24,9 @@ const tags = await getAllContentTagCounts();
     </div>
 
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
-      <h1 class="text-3xl font-semibold text-foreground font-display">All Tags</h1>
+      <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
+        All Tags
+      </h1>
       <p class="text-sm text-muted-foreground">Browse posts and projects by topic</p>
     </div>
 

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -24,7 +24,7 @@ const tags = await getAllContentTagCounts();
     </div>
 
     <div class="flex flex-col gap-y-2 page-enter page-enter-delay-2">
-      <h1 class="text-3xl font-semibold text-foreground">All Tags</h1>
+      <h1 class="text-3xl font-semibold text-foreground font-display">All Tags</h1>
       <p class="text-sm text-muted-foreground">Browse posts and projects by topic</p>
     </div>
 

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -27,7 +27,7 @@ const tags = await getAllContentTagCounts();
       <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-foreground font-display">
         All Tags
       </h1>
-      <p class="text-sm text-muted-foreground">Browse posts and projects by topic</p>
+      <p class="text-base text-muted-foreground">Browse posts and projects by topic</p>
     </div>
 
     {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 
 @theme inline {
   --font-sans: "Satoshi", system-ui, sans-serif;
-  --font-display: "Space Grotesk", "Satoshi", system-ui, sans-serif;
+  --font-display: "Bricolage Grotesque", "Satoshi", system-ui, sans-serif;
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,7 @@
 
 @theme inline {
   --font-sans: "Satoshi", system-ui, sans-serif;
+  --font-display: "Clash Display", "Satoshi", system-ui, sans-serif;
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 
 @theme inline {
   --font-sans: "Satoshi", system-ui, sans-serif;
-  --font-display: "Clash Display", "Satoshi", system-ui, sans-serif;
+  --font-display: "Space Grotesk", "Satoshi", system-ui, sans-serif;
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);


### PR DESCRIPTION
## Summary

Introduce Clash Display as the display/identity font alongside Satoshi for body text, apply it across all pages, restructure section labels into a two-layered format, and fix design violations found in the about page critique.

## Changes

- Add Clash Display (Fontshare) alongside Satoshi for a two-font typographic system
- Apply `font-display` to hero greeting, about name, page titles, blog/project detail titles, section labels, and 404 page
- Restructure section labels into two-layered format (Clash Display primary + Satoshi descriptive sublabel) across landing, about, blog, and projects pages
- Remove side-stripe accent bars (`w-[3px]` divs) from section labels on about page and landing page (design ban violation)
- Replace `text-foreground/80` and `text-foreground/70` with `text-foreground` on about page (WCAG AA contrast fix: 3.21:1 and 2.69:1 → 4.68:1 on light theme)
- Add `--font-display` CSS token in Tailwind theme
- Update DESIGN.md typography section to document the pairing, two-family rule, and label pair rule
- Update CHANGELOG.md

## Testing

- [x] `bun run verify` passes (type-check, lint, format, test, build)
- [x] Visual check: hero greeting renders in Clash Display
- [x] Visual check: section labels show two-layered format
- [x] Visual check: about page body text contrast is full foreground
- [x] Side-stripe markers removed from about and landing pages

## Notes

This is the typography phase (Phase 1) of the about page refactor. The layout/structure redesign of the about page (Phase 2) will follow in a separate PR after reviewing the preview deployment.

## References

- Ticket/Issue: N/A