### PR TITLE
fix: prevent mobile horizontal overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ All notable changes to this site are documented in this file.
 
 ### Fixed — 2026-06-12
 
+- Prevent page containers with inline padding from causing horizontal scrolling
+  on mobile viewports.
 - Restore CI compatibility with Biome 2.5 by migrating the Biome config,
   removing unsupported ARIA from the empty-state container, and adding an
   accessible title to the generated favicon SVG.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -92,9 +92,16 @@
    Base Styles
    ========================================================================== */
 html {
+  box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
 }
 
 body,


### PR DESCRIPTION
## Summary
Adds a global border-box sizing reset so padded full-width layout containers no longer exceed mobile viewport width. This targets the horizontal page scroll seen on iPhone-sized screens without changing the existing layout structure.

## Changes
- Set the root document sizing model to border-box.
- Inherit border-box sizing through all elements and pseudo-elements.
- Document the mobile overflow fix in the changelog.

## Testing
**Automated**
- [x] bun run test passed (18 tests)
- [x] bun run verify passed

**Manual**
- [x] Verify on an iPhone or mobile viewport that the site no longer scrolls horizontally.