### PR TITLE
feat: refresh site copy and SEO metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Changed — 2026-06-13
+
+- Refresh static page copy, route metadata, and social preview titles around a
+  backend-engineer positioning while keeping page headings concise.
+
 ### Added — 2026-06-12
 
 - New `/notes` route with full-content-inline listing and individual permalink

--- a/src/components/seo/SEO.astro
+++ b/src/components/seo/SEO.astro
@@ -29,12 +29,13 @@ const {
 } = Astro.props;
 
 const routeMetadata = getRouteMetadata(Astro.url.pathname);
-const resolvedTitle = title ?? routeMetadata?.title ?? SITE.title;
+const resolvedTitle = title ?? routeMetadata?.seoTitle ?? routeMetadata?.title ?? SITE.title;
 const resolvedDescription = description ?? routeMetadata?.description ?? SITE.description;
 const resolvedType = type ?? routeMetadata?.type ?? "website";
 const resolvedImageAlt = imageAlt ?? `${resolvedTitle} - ${resolvedDescription}`;
 const resolvedCanonicalURL =
   canonicalURL ?? new URL(normalizePagePath(Astro.url.pathname), Astro.site).href;
+const resolvedSocialTitle = title ? resolvedTitle : routeMetadata?.title ?? resolvedTitle;
 
 const ogType = article ? "article" : resolvedType;
 const ogImagePath = image ?? getOgImagePath(Astro.url.pathname);
@@ -53,7 +54,7 @@ const ogImage = new URL(ogImagePath, Astro.site).href;
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content={ogType} />
 <meta property="og:url" content={resolvedCanonicalURL} />
-<meta property="og:title" content={resolvedTitle} />
+<meta property="og:title" content={resolvedSocialTitle} />
 <meta property="og:description" content={resolvedDescription} />
 <meta property="og:image" content={ogImage} />
 <meta property="og:image:alt" content={resolvedImageAlt} />
@@ -77,7 +78,7 @@ const ogImage = new URL(ogImagePath, Astro.site).href;
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:url" content={resolvedCanonicalURL} />
-<meta name="twitter:title" content={resolvedTitle} />
+<meta name="twitter:title" content={resolvedSocialTitle} />
 <meta name="twitter:description" content={resolvedDescription} />
 <meta name="twitter:image" content={ogImage} />
 <meta name="twitter:image:alt" content={resolvedImageAlt} />

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,7 +2,7 @@
 export const SITE = {
   // Meta
   title: "Abijith S",
-  description: "Personal portfolio and blog of Abijith S — developer, builder, writer.",
+  description: "Backend engineer in Kochi, Kerala. I work with Java and Spring Boot.",
   url: "https://abijith.sh",
   domain: "abijith.sh",
   locale: "en-US",
@@ -10,7 +10,7 @@ export const SITE = {
   // Author
   author: "Abijith S",
   fullName: "Abijith Suresh",
-  tagline: "Backend engineer at UST. Kochi, Kerala.",
+  tagline: "Backend engineer based in Kochi, Kerala.",
   avatar: "/avatar.jpg",
   twitterHandle: "@abijith_sh", // Kept for SEO compatibility (twitter:creator metadata)
 

--- a/src/lib/route-metadata.ts
+++ b/src/lib/route-metadata.ts
@@ -3,6 +3,7 @@ import { SITE } from "@/consts";
 export interface RouteMetadata {
   path: string;
   title: string;
+  seoTitle?: string;
   description: string;
   type?: "website" | "article" | "profile";
 }
@@ -16,32 +17,38 @@ export const STATIC_ROUTE_METADATA = [
   {
     path: "/about/",
     title: "About",
-    description: "About Abijith S, this site, and the work behind it.",
+    seoTitle: `About - ${SITE.title}`,
+    description: "Backend engineer based in Kochi, Kerala.",
     type: "profile",
   },
   {
     path: "/writing/",
     title: "Writing",
-    description: "Standalone pieces, technical notes, and reflections.",
+    seoTitle: `Writing - ${SITE.title}`,
+    description: "Things I've written.",
   },
   {
     path: "/projects/",
     title: "Projects",
-    description: "Shipped work, side projects, and experiments.",
+    seoTitle: `Projects - ${SITE.title}`,
+    description: "Things I've built and shipped.",
   },
   {
     path: "/notes/",
     title: "Notes",
-    description: "Short thoughts and quick posts.",
+    seoTitle: `Notes - ${SITE.title}`,
+    description: "Short thoughts.",
   },
   {
     path: "/now/",
     title: "Now",
-    description: "What I'm doing right now.",
+    seoTitle: `Now - ${SITE.title}`,
+    description: "What I'm currently up to.",
   },
   {
     path: "/404/",
     title: "Page Not Found",
+    seoTitle: `Page Not Found - ${SITE.title}`,
     description: "The page you are looking for does not exist.",
   },
 ] satisfies RouteMetadata[];
@@ -56,6 +63,12 @@ export function normalizePagePath(pathname: string): string {
 export function getRouteMetadata(pathname: string): RouteMetadata | undefined {
   const normalizedPath = normalizePagePath(pathname);
   return STATIC_ROUTE_METADATA.find((route) => route.path === normalizedPath);
+}
+
+export function getStaticRouteMetadata(pathname: string): RouteMetadata {
+  const metadata = getRouteMetadata(pathname);
+  if (!metadata) throw new Error(`Missing static route metadata for ${pathname}`);
+  return metadata;
 }
 
 export function getOgImagePath(pathname: string): string {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,11 +2,13 @@
 import ContentDetailPage from "@/components/ContentDetailPage.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
+import { getStaticRouteMetadata } from "@/lib/route-metadata";
+
+const routeMetadata = getStaticRouteMetadata("/about/");
 ---
 
 <Layout
-  title={`About - ${SITE.title}`}
-  description="About Abijith S, this site, and the work behind it."
+  description={routeMetadata.description}
   type="profile"
   jsonLd={{
     type: "person",
@@ -17,26 +19,46 @@ import Layout from "@/layouts/Layout.astro";
   }}
 >
   <ContentDetailPage
-    title="About"
-    description="Backend engineer, builder, and writer based in Kochi, Kerala."
+    title={routeMetadata.title}
+    description={routeMetadata.description}
   >
     <p>
-      I am Abijith S, a backend engineer at UST. I work mostly with Java, Spring Boot,
-      and backend systems, and I use this site as a place to collect the work I build
-      and the things I learn along the way.
+      I'm a backend engineer at <a
+        href="https://ust.com"
+        target="_blank"
+        rel="noopener noreferrer">UST</a
+      > — born in <a
+        href="https://en.wikipedia.org/wiki/Kochi"
+        target="_blank"
+        rel="noopener noreferrer">Kochi</a
+      >, still here. I got into programming through QBasic in Class 9. The teacher set
+      problems just past what you could do. That stuck.
     </p>
 
     <p>
-      The site is intentionally small. Projects are the proof, writing is where I
-      develop ideas, and notes are for smaller thoughts that still deserve a stable
-      place on the web.
+      On the side I've built tools that run entirely in your browser. No servers, no
+      accounts, files stay local. It started because I couldn't find a simple image
+      resizer I trusted, so I built one. That kept going.
     </p>
 
     <p>
-      You can find me on <a href="https://github.com/abijith-suresh">GitHub</a>,
-      <a href="https://x.com/abijith_sh">X</a>,
-      <a href="https://linkedin.com/in/abijith-suresh">LinkedIn</a>, and
-      <a href="https://bsky.app/profile/abijith.bsky.social">Bluesky</a>.
+      You can find me on <a
+        href="https://github.com/abijith-suresh"
+        target="_blank"
+        rel="noopener noreferrer">GitHub</a
+      >, <a
+        href="https://x.com/abijith_sh"
+        target="_blank"
+        rel="noopener noreferrer">X</a
+      >, <a
+        href="https://linkedin.com/in/abijith-suresh"
+        target="_blank"
+        rel="noopener noreferrer">LinkedIn</a
+      >, and <a
+        href="https://bsky.app/profile/abijith.bsky.social"
+        target="_blank"
+        rel="noopener noreferrer">Bluesky</a
+      >.
     </p>
   </ContentDetailPage>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,8 +20,13 @@ import Layout from "@/layouts/Layout.astro";
           class="text-link"
           target="_blank"
           rel="noopener noreferrer">UST</a
-        >. I work on backend systems, mostly Java and Spring Boot. Currently building things and
-        writing about them.
+        > in <a
+          href="https://en.wikipedia.org/wiki/Kochi"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">Kochi, Kerala</a
+        >. I work with Java and Spring Boot. Outside work, I'm usually playing games or building
+        something.
       </p>
       <p style="color:var(--color-muted-foreground)">
         You can read more <a href="/about/" class="text-link">about me</a>,

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -5,12 +5,14 @@ import PageShell from "@/components/ui/PageShell.astro";
 import Layout from "@/layouts/Layout.astro";
 import NoteCard from "@/components/NoteCard.astro";
 import { getAllNotes } from "@/lib/notes";
+import { getStaticRouteMetadata } from "@/lib/route-metadata";
 
 const allNotes = await getAllNotes();
+const routeMetadata = getStaticRouteMetadata("/notes/");
 ---
 
 <Layout>
-  <PageShell title="Notes" subtitle="Short thoughts and quick posts">
+  <PageShell title={routeMetadata.title} subtitle={routeMetadata.description}>
     {allNotes.length > 0 ? (
       <Container>
         {allNotes.map((entry) => (

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -2,38 +2,49 @@
 import Container from "@/components/ui/Container.astro";
 import PageShell from "@/components/ui/PageShell.astro";
 import Layout from "@/layouts/Layout.astro";
+import { getStaticRouteMetadata } from "@/lib/route-metadata";
+
+const routeMetadata = getStaticRouteMetadata("/now/");
 ---
 
 <Layout>
-  <PageShell title="Now" subtitle="What I'm doing right now.">
+  <PageShell title={routeMetadata.title} subtitle={routeMetadata.description}>
     <Container class="section-flow">
       <p style="color:var(--color-muted-foreground)">
         Last updated: June 2026
       </p>
 
       <p style="color:var(--color-muted-foreground)">
-        Working as a backend engineer at UST in Kochi, Kerala. Building backend systems with Java
-        and Spring Boot.
+        At work, I'm working with Java and Spring Boot at <a
+          href="https://ust.com"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">UST</a
+        >.
       </p>
 
       <p style="color:var(--color-muted-foreground)">
-        Currently learning [add what you're learning here].
+        Building — <a
+          href="https://github.com/abijith-suresh/interleaf"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">Interleaf</a
+        >, a client-side PDF editor. Also early days on something new for the CLI. Not ready to
+        say much yet.
       </p>
 
       <p style="color:var(--color-muted-foreground)">
-        Reading [add book here].
-      </p>
-
-      <p style="color:var(--color-muted-foreground)">
-        Working on [add project here].
-      </p>
-
-      <p style="color:var(--color-muted-foreground)">
-        Listening to [add music/podcast here].
-      </p>
-
-      <p style="color:var(--color-muted-foreground)">
-        Based in Kochi, Kerala. The weather is [add weather here].
+        Playing — <a
+          href="https://store.steampowered.com/app/365590/Tom_Clancys_The_Division/"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">The Division</a
+        > and <a
+          href="https://store.steampowered.com/app/289070/Sid_Meiers_Civilization_VI/"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">Civilization VI</a
+        >.
       </p>
     </Container>
   </PageShell>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -6,13 +6,15 @@ import ProjectCard from "@/components/ProjectCard.astro";
 import Layout from "@/layouts/Layout.astro";
 import { groupByYear } from "@/lib/group-by-year";
 import { getAllProjects } from "@/lib/projects";
+import { getStaticRouteMetadata } from "@/lib/route-metadata";
 
 const allProjects = await getAllProjects();
 const projectsByYear = groupByYear(allProjects, (project) => project.data.publishedDate);
+const routeMetadata = getStaticRouteMetadata("/projects/");
 ---
 
 <Layout>
-  <PageShell title="Projects" subtitle="Shipped work, side projects, and experiments">
+  <PageShell title={routeMetadata.title} subtitle={routeMetadata.description}>
     {
       allProjects.length > 0 ? (
         <Container>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -6,13 +6,15 @@ import WritingCard from "@/components/WritingCard.astro";
 import Layout from "@/layouts/Layout.astro";
 import { getAllWriting } from "@/lib/writing";
 import { groupByYear } from "@/lib/group-by-year";
+import { getStaticRouteMetadata } from "@/lib/route-metadata";
 
 const allPosts = await getAllWriting();
 const postsByYear = groupByYear(allPosts, (post) => post.data.publishedDate);
+const routeMetadata = getStaticRouteMetadata("/writing/");
 ---
 
 <Layout>
-  <PageShell title="Writing" subtitle="Notes, write-ups, and the occasional opinion">
+  <PageShell title={routeMetadata.title} subtitle={routeMetadata.description}>
     {
       allPosts.length > 0 ? (
         <Container>


### PR DESCRIPTION
## Summary

- Refreshes landing, About, index page, and Now page copy around the agreed backend-engineer positioning.
- Keeps static page subtitles and route metadata in sync while adding separate SEO titles for browser/search results.
- Updates selected external links for UST, Kochi, Interleaf, and the games, with no favicon or cache-busting changes.

## Validation

- `bun run verify`
- Pre-push hook reran `bun run verify` successfully