### PR TITLE
fix(about): use top-level page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Changed — 2026-06-14
+
+- Update the about page to use the same top-level page layout as other static
+  pages, removing the article-style divider and extra header spacing.
+
 ### Changed — 2026-06-13
 
 - Refresh static page copy, route metadata, and social preview titles around a

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,5 +1,6 @@
 ---
-import ContentDetailPage from "@/components/ContentDetailPage.astro";
+import Container from "@/components/ui/Container.astro";
+import PageShell from "@/components/ui/PageShell.astro";
 import { SITE } from "@/consts";
 import Layout from "@/layouts/Layout.astro";
 import { getStaticRouteMetadata } from "@/lib/route-metadata";
@@ -18,47 +19,52 @@ const routeMetadata = getStaticRouteMetadata("/about/");
     },
   }}
 >
-  <ContentDetailPage
-    title={routeMetadata.title}
-    description={routeMetadata.description}
-  >
-    <p>
-      I'm a backend engineer at <a
-        href="https://ust.com"
-        target="_blank"
-        rel="noopener noreferrer">UST</a
-      > — born in <a
-        href="https://en.wikipedia.org/wiki/Kochi"
-        target="_blank"
-        rel="noopener noreferrer">Kochi</a
-      >, still here. I got into programming through QBasic in Class 9. The teacher set
-      problems just past what you could do. That stuck.
-    </p>
+  <PageShell title={routeMetadata.title} subtitle={routeMetadata.description}>
+    <Container class="section-flow">
+      <p style="color:var(--color-muted-foreground)">
+        I'm a backend engineer at <a
+          href="https://ust.com"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">UST</a
+        > — born in <a
+          href="https://en.wikipedia.org/wiki/Kochi"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">Kochi</a
+        >, still here. I got into programming through QBasic in Class 9. The teacher
+        set problems just past what you could do. That stuck.
+      </p>
 
-    <p>
-      On the side I've built tools that run entirely in your browser. No servers, no
-      accounts, files stay local. It started because I couldn't find a simple image
-      resizer I trusted, so I built one. That kept going.
-    </p>
+      <p style="color:var(--color-muted-foreground)">
+        On the side I've built tools that run entirely in your browser. No servers,
+        no accounts, files stay local. It started because I couldn't find a simple
+        image resizer I trusted, so I built one. That kept going.
+      </p>
 
-    <p>
-      You can find me on <a
-        href="https://github.com/abijith-suresh"
-        target="_blank"
-        rel="noopener noreferrer">GitHub</a
-      >, <a
-        href="https://x.com/abijith_sh"
-        target="_blank"
-        rel="noopener noreferrer">X</a
-      >, <a
-        href="https://linkedin.com/in/abijith-suresh"
-        target="_blank"
-        rel="noopener noreferrer">LinkedIn</a
-      >, and <a
-        href="https://bsky.app/profile/abijith.bsky.social"
-        target="_blank"
-        rel="noopener noreferrer">Bluesky</a
-      >.
-    </p>
-  </ContentDetailPage>
+      <p style="color:var(--color-muted-foreground)">
+        You can find me on <a
+          href="https://github.com/abijith-suresh"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">GitHub</a
+        >, <a
+          href="https://x.com/abijith_sh"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">X</a
+        >, <a
+          href="https://linkedin.com/in/abijith-suresh"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">LinkedIn</a
+        >, and <a
+          href="https://bsky.app/profile/abijith.bsky.social"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">Bluesky</a
+        >.
+      </p>
+    </Container>
+  </PageShell>
 </Layout>


### PR DESCRIPTION
## Summary
The about page now uses the shared top-level page shell instead of the article/detail layout. This removes the article-style divider and aligns the title/subtitle spacing with the other static pages.

## Changes
- Replaced `ContentDetailPage` on `/about/` with `PageShell` and `Container`.
- Applied the shared `text-link` styling to about page links.
- Added a changelog entry for the layout adjustment.

## Testing
**Automated**
- [x] `bun run verify` passed (18 tests)

**Manual**
- [ ] Confirm `/about/` header spacing and lack of divider match the other top-level pages.