### PR TITLE
feat: update about subtitle and now page content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ Browse `src/components/` and `src/lib/` for existing patterns before introducing
     (e.g., `### Removed — YYYY-MM-DD`). If a subsection with today's
     date and the same category already exists, append to it instead of
     creating a duplicate.
+- Never create duplicate subsection headers for the same date in `CHANGELOG.md`.
+  If a subsection with today's date and category already exists, append entries
+  to it instead of creating a new one.
+- Do not use Goodreads links. Prefer Wikipedia, Google Books, or official publisher
+  links for book references.
 - Run `bun run verify` before every push.
 - Commit and PR titles must use Conventional Commits (`feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`).
 - Branch from the latest `main`; never commit directly to `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,7 @@ Browse `src/components/` and `src/lib/` for existing patterns before introducing
 - Never create duplicate subsection headers for the same date in `CHANGELOG.md`.
   If a subsection with today's date and category already exists, append entries
   to it instead of creating a new one.
-- Do not use Goodreads links. Prefer Wikipedia, Google Books, or official publisher
-  links for book references.
+- Prefer Goodreads links for book references.
 - Run `bun run verify` before every push.
 - Commit and PR titles must use Conventional Commits (`feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`).
 - Branch from the latest `main`; never commit directly to `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,13 @@ All notable changes to this site are documented in this file.
 
 ### Changed — 2026-07-14
 
-- Refresh the about page subtitle and related metadata to "My life in a minute."
-- Update the now page with current games (Call of Duty: Modern Warfare 2019, The Division)
-  and reading (Deep Work by Cal Newport).
-
-### Changed — 2026-07-14
-
 - Migrate to Astro v7 (upgrade from v6.4.6). Change `trailingSlash` from `"always"`
   to `"ignore"` to fix `NoMatchingStaticPathFound` error with prerendered OG
   image endpoints, which no longer support forced trailing slashes on file-type
   routes.
+- Refresh the about page subtitle and related metadata to "My life in a minute."
+- Update the now page with current games (Call of Duty: Modern Warfare 2019, The Division)
+  and reading (Deep Work by Cal Newport).
 
 ### Changed — 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this site are documented in this file.
 
 ### Changed — 2026-07-14
 
+- Refresh the about page subtitle and related metadata to "My life in a minute."
+- Update the now page with current games (Call of Duty: Modern Warfare 2019, The Division)
+  and reading (Deep Work by Cal Newport).
+
+### Changed — 2026-07-14
+
 - Migrate to Astro v7 (upgrade from v6.4.6). Change `trailingSlash` from `"always"`
   to `"ignore"` to fix `NoMatchingStaticPathFound` error with prerendered OG
   image endpoints, which no longer support forced trailing slashes on file-type

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -10,7 +10,7 @@ export const SITE = {
   // Author
   author: "Abijith S",
   fullName: "Abijith Suresh",
-  tagline: "Backend engineer based in Kochi, Kerala.",
+  tagline: "My life in a minute.",
   avatar: "/avatar.jpg",
   twitterHandle: "@abijith_sh", // Kept for SEO compatibility (twitter:creator metadata)
 

--- a/src/lib/route-metadata.ts
+++ b/src/lib/route-metadata.ts
@@ -18,7 +18,7 @@ export const STATIC_ROUTE_METADATA = [
     path: "/about/",
     title: "About",
     seoTitle: `About - ${SITE.title}`,
-    description: "Backend engineer based in Kochi, Kerala.",
+    description: "My life in a minute.",
     type: "profile",
   },
   {

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -49,7 +49,7 @@ const routeMetadata = getStaticRouteMetadata("/now/");
 
       <p style="color:var(--color-muted-foreground)">
         Reading — <a
-          href="https://www.goodreads.com/book/show/36812946-deep-work"
+          href="https://en.wikipedia.org/wiki/Deep_Work"
           class="text-link"
           target="_blank"
           rel="noopener noreferrer">Deep Work</a

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -11,7 +11,7 @@ const routeMetadata = getStaticRouteMetadata("/now/");
   <PageShell title={routeMetadata.title} subtitle={routeMetadata.description}>
     <Container class="section-flow">
       <p style="color:var(--color-muted-foreground)">
-        Last updated: June 2026
+        Last updated: July 2026
       </p>
 
       <p style="color:var(--color-muted-foreground)">
@@ -40,11 +40,20 @@ const routeMetadata = getStaticRouteMetadata("/now/");
           target="_blank"
           rel="noopener noreferrer">The Division</a
         > and <a
-          href="https://store.steampowered.com/app/289070/Sid_Meiers_Civilization_VI/"
+          href="https://store.steampowered.com/app/1385850/Call_of_Duty_Modern_Warfare/"
           class="text-link"
           target="_blank"
-          rel="noopener noreferrer">Civilization VI</a
-        >.
+          rel="noopener noreferrer">Call of Duty: Modern Warfare</a
+        > (2019).
+      </p>
+
+      <p style="color:var(--color-muted-foreground)">
+        Reading — <a
+          href="https://www.goodreads.com/book/show/36812946-deep-work"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">Deep Work</a
+        > by Cal Newport.
       </p>
     </Container>
   </PageShell>

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -49,7 +49,7 @@ const routeMetadata = getStaticRouteMetadata("/now/");
 
       <p style="color:var(--color-muted-foreground)">
         Reading — <a
-          href="https://en.wikipedia.org/wiki/Deep_Work"
+          href="https://books.google.com/books?id=lZpFCgAAQBAJ"
           class="text-link"
           target="_blank"
           rel="noopener noreferrer">Deep Work</a

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -49,7 +49,7 @@ const routeMetadata = getStaticRouteMetadata("/now/");
 
       <p style="color:var(--color-muted-foreground)">
         Reading — <a
-          href="https://books.google.com/books?id=lZpFCgAAQBAJ"
+          href="https://www.goodreads.com/book/show/36812946-deep-work"
           class="text-link"
           target="_blank"
           rel="noopener noreferrer">Deep Work</a


### PR DESCRIPTION
### Changes

- **About page subtitle** — changed from "Backend engineer based in Kochi, Kerala." to "My life in a minute." (also updates  tagline and route metadata description used in SEO / OG images)
- **Now page** — replaced Civilization VI with Call of Duty: Modern Warfare 2019 in the playing section, added a reading section with Deep Work by Cal Newport, and bumped the last-updated date to July 2026

### Review

Check that the about page reads well and the now page content looks right.