### PR TITLE
fix: correct COD link and rephrase work entry on now page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Fixed — 2026-07-14
+
+- Correct the Call of Duty: Modern Warfare Steam link to the correct app ID
+  (2000950 instead of 1385850).
+- Rephrase the work entry on the now page for a more casual, concise tone.
+
 ### Changed — 2026-07-14
 
 - Migrate to Astro v7 (upgrade from v6.4.6). Change `trailingSlash` from `"always"`

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -15,12 +15,12 @@ const routeMetadata = getStaticRouteMetadata("/now/");
       </p>
 
       <p style="color:var(--color-muted-foreground)">
-        At work, I'm working with Java and Spring Boot at <a
+        Still at <a
           href="https://ust.com"
           class="text-link"
           target="_blank"
           rel="noopener noreferrer">UST</a
-        >.
+        >, writing Java and Spring Boot.
       </p>
 
       <p style="color:var(--color-muted-foreground)">
@@ -40,7 +40,7 @@ const routeMetadata = getStaticRouteMetadata("/now/");
           target="_blank"
           rel="noopener noreferrer">The Division</a
         > and <a
-          href="https://store.steampowered.com/app/1385850/Call_of_Duty_Modern_Warfare/"
+          href="https://store.steampowered.com/app/2000950/Call_of_Duty_Modern_Warfare/"
           class="text-link"
           target="_blank"
           rel="noopener noreferrer">Call of Duty: Modern Warfare</a


### PR DESCRIPTION
- Fix Call of Duty: Modern Warfare Steam link to correct app ID (2000950)\n- Rephrase work entry from 'At work, I'm working with Java and Spring Boot at UST.' to 'Still at UST, writing Java and Spring Boot.'