### PR TITLE
chore: configure dependabot weekly, limit 10, and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,11 @@ updates:
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
       time: "09:00"
       timezone: "Asia/Kolkata"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
     commit-message:
@@ -20,14 +21,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        auto-merge: "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
       time: "09:30"
       timezone: "Asia/Kolkata"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "github-actions"
@@ -41,3 +44,4 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        auto-merge: "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Changed — 2026-07-14
+
+- Configure dependabot on a weekly schedule (Mondays), increase open-PR limits
+  (bun: 5→10, actions: 2→5), and enable auto-merge for minor/patch groups.
+
 ### Fixed — 2026-07-14
 
 - Correct the Call of Duty: Modern Warfare Steam link to the correct app ID


### PR DESCRIPTION
### Changes

- **Schedule**: monthly → weekly (Mondays)
- **Open PR limit**: Bun 5 → 10, Actions 2 → 5
- **Auto-merge** enabled on the minor-and-patch group for both ecosystems

### What stays the same

- Major version bumps still arrive as individual PRs for human review
- Labels, commit prefixes, and grouping strategy unchanged