### PR TITLE
fix: use GITHUB_TOKEN and skip title validation for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
-          github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       # Skip major bumps — they deserve human review.
       - name: Enable auto-merge for patch and minor updates
@@ -31,4 +31,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,6 +11,7 @@ jobs:
   pr-title:
     name: pr-title
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     steps:
       - name: Validate PR title


### PR DESCRIPTION
## Changes

Two fixes to the Dependabot auto-merge workflow:

1. **`dependabot-auto-merge.yml`** — Replace `secrets.DEPENDABOT_AUTOMERGE_PAT` with `secrets.GITHUB_TOKEN`. The PAT was removed from the repo secrets and `GITHUB_TOKEN` is the standard approach used by major projects (Google, Microsoft, AWS, Spatie, etc.).

2. **`pr-title.yml`** — Skip PR title validation for Dependabot PRs. Dependabot's auto-generated titles often exceed the 72-character conventional-commit limit, causing auto-merge to fail. This adds `if: github.event.pull_request.user.login != 'dependabot[bot]'` to bypass the check for Dependabot.

## Verification

- [x] `bun run type-check` — 0 errors
- [x] `bun run lint` — no issues
- [x] `bun run format:check` — clean
- [x] `bun run test` — 18/18 passed
- [x] `bun run build` — 15 pages built