### PR TITLE
fix: use squash merge strategy for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,7 @@ jobs:
         if: >
           steps.metadata.outputs.update-type == 'version-update:semver-patch'
           || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Fix

The repo only allows squash commits, but the auto-merge workflow was using `--merge` (merge commit). Changed to `--squash` to match the repository's merge strategy.

```diff
- gh pr merge --auto --merge "$PR_URL"
+ gh pr merge --auto --squash "$PR_URL"
```

## Context

This caused auto-merge to fail on PR #272 after CI passed — GitHub rejected the merge commit since the repo is configured for squash-only merges.