### PR TITLE
chore: standardize DevOps config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize line endings to LF
+* text=auto eol=lf
+
+# Denote files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.svg text
+*.woff binary
+*.woff2 binary
+*.eot binary
+*.ttf binary
+*.lock -diff
+
+# GitHub linguist overrides
+.changeset/** linguist-generated=true
+CHANGELOG.md linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: quality

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,7 @@ jobs:
         if: >
           steps.metadata.outputs.update-type == 'version-update:semver-patch'
           || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,33 +1,55 @@
 name: Dependabot auto-merge
 
-on:
-  pull_request:
+on: pull_request_target
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: dependabot-auto-merge
+  cancel-in-progress: false
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-
-    # Only act on Dependabot PRs in this repo.
     if: >
       github.event.pull_request.user.login == 'dependabot[bot]'
       && github.repository == 'abijith-suresh/abijith.sh'
 
     steps:
-      - name: Fetch Dependabot metadata
+      - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Skip major bumps — they deserve human review.
-      - name: Enable auto-merge for patch and minor updates
+      # Patch & minor updates → always auto-merge (safe by definition)
+      - name: Auto-merge patch and minor updates
         if: >
           steps.metadata.outputs.update-type == 'version-update:semver-patch'
           || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Dev dependency majors → auto-merge (CI gate is sufficient)
+      - name: Auto-merge major updates for dev dependencies
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+          && steps.metadata.outputs.dependency-type == 'direct:development'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Runtime dependency majors → auto-merge only if compat score ≥ 90
+      - name: Auto-merge major updates for runtime deps with high compat
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+          && steps.metadata.outputs.dependency-type == 'direct:production'
+          && steps.metadata.outputs.compatibility-score >= 90
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^(feat|fix|docs|refactor|chore|test|ci)(\([a-z0-9][a-z0-9/-]*\))?(!)?: .+$'
+          pattern='^(feat|fix|docs|refactor|chore|test|ci|build)(\([a-z0-9][a-z0-9/-]*\))?(!)?: .+$'
 
           if [[ ! "$PR_TITLE" =~ $pattern ]]; then
             printf 'PR title must match Conventional Commits: type(optional-scope): subject\n' >&2

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,4 +1,4 @@
-const types = ["feat", "fix", "docs", "refactor", "chore", "test", "ci"];
+const types = ["feat", "fix", "docs", "refactor", "chore", "test", "ci", "build"];
 
 export default {
   extends: ["@commitlint/config-conventional"],


### PR DESCRIPTION
Standardizes abijith.sh to match the new repo-wide configuration templates:

- Add `build` type to commitlint and PR title validation
- Add `concurrency` block to CI workflow
- Switch Dependabot auto-merge to `pull_request_target` and add 3-tier major bumps strategy:
  - Patch/minor: auto-merge always
  - Dev dependency majors: auto-merge (CI gate is sufficient)
  - Runtime dependency majors: auto-merge if compat score ≥ 90
  - Everything else: manual review
- Add .gitattributes for line ending normalization