### PR TITLE
chore: migrate generic workflows to central v0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,30 +13,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality:
-    name: quality
+  bun-quality:
+    uses: abijith-suresh/workflows/.github/workflows/bun-quality.yml@0f257b2642d2a010fefe0ff9d03374799d73eb44 # v0.3.0
+
+  dependency-review:
+    name: dependency-review
+    needs: bun-quality
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version-file: ".node-version"
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: ".bun-version"
-          cache: true
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run quality gate
-        run: bun run verify
-
       - name: Dependency review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+
+  quality:
+    name: quality
+    if: ${{ always() }}
+    needs: [bun-quality, dependency-review]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Aggregate quality checks
+        env:
+          BUN_QUALITY_RESULT: ${{ needs.bun-quality.result }}
+          DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$BUN_QUALITY_RESULT" != "success" || "$DEPENDENCY_REVIEW_RESULT" != "success" ]]; then
+            printf 'Bun quality: %s; dependency review: %s\n' "$BUN_QUALITY_RESULT" "$DEPENDENCY_REVIEW_RESULT" >&2
+            exit 1
+          fi
+
+          echo 'Bun quality and dependency review passed.'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,29 +8,25 @@ permissions:
   pull-requests: read
 
 jobs:
+  title-check:
+    uses: abijith-suresh/workflows/.github/workflows/conventional-commit-title.yml@0f257b2642d2a010fefe0ff9d03374799d73eb44 # v0.3.0
+
   pr-title:
     name: pr-title
+    if: ${{ always() }}
+    needs: title-check
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     steps:
-      - name: Validate PR title
+      - name: Aggregate title check
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          TITLE_CHECK_RESULT: ${{ needs.title-check.result }}
         run: |
-          pattern='^(feat|fix|docs|refactor|chore|test|ci|build)(\([a-z0-9][a-z0-9/-]*\))?(!)?: .+$'
+          set -euo pipefail
 
-          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
-            printf 'PR title must match Conventional Commits: type(optional-scope): subject\n' >&2
+          if [[ "$TITLE_CHECK_RESULT" != "success" ]]; then
+            printf 'Conventional Commit title check: %s\n' "$TITLE_CHECK_RESULT" >&2
             exit 1
           fi
 
-          if (( ${#PR_TITLE} > 72 )); then
-            printf 'PR title must be 72 characters or fewer\n' >&2
-            exit 1
-          fi
-
-          if [[ "$PR_TITLE" == *. ]]; then
-            printf 'PR title subject must not end with a period\n' >&2
-            exit 1
-          fi
+          echo 'Conventional Commit title check passed.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Changed — 2026-08-03
+
+- Migrate generic Bun quality and Conventional Commit title checks to the
+  pinned `abijith-suresh/workflows` v0.3.0 reusable workflows while retaining
+  local dependency review and required-check aliases.
+
 ### Changed — 2026-07-30
 
 - Standardize DevOps configuration: add `.gitattributes`, enforce PR title


### PR DESCRIPTION
## Summary

- Replace the local Bun install/verify steps with the pinned `bun-quality.yml` reusable workflow from `abijith-suresh/workflows` v0.3.0
- Replace local PR-title validation with the pinned `conventional-commit-title.yml` reusable workflow
- Keep dependency review local at its current scope and retain local `quality` and `pr-title` aggregation checks for existing required status names
- Preserve triggers, concurrency, and project-specific repository configuration

## Validation

- `bun install --frozen-lockfile`
- `bun run verify`
- `actionlint .github/workflows/*.yml`
- `prettier --check .github/workflows/*.yml CHANGELOG.md`
- `git diff --check`
- `.bun-version` matches `packageManager: bun@1.3.13`

## Branch protection

No branch protection settings were changed. The current required contexts are `quality` and `pr-title`; local aliases with those names remain and fail if their corresponding reusable/local checks fail. The new reusable-workflow check names should be reviewed after merge; updating required contexts, if desired, is a separate owner-reviewed settings follow-up.

Please leave this PR open for owner review.
