### PR TITLE
chore: refresh now page with current work, media, and reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Changed — 2026-08-15
+
+- Refresh the now page: work (Java only), building (Interleaf only), playing
+  (The Division 2), watching (Frieren season 2), and reading (Better Than the
+  Movies by Lynn Painter).
+
 ### Removed — 2026-08-15
 
 - Notes route, content collection, pages, components, and all related links.

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -11,7 +11,7 @@ const routeMetadata = getStaticRouteMetadata("/now/");
   <PageShell title={routeMetadata.title} subtitle={routeMetadata.description}>
     <Container class="section-flow">
       <p style="color:var(--color-muted-foreground)">
-        Last updated: July 2026
+        Last updated: August 2026
       </p>
 
       <p style="color:var(--color-muted-foreground)">
@@ -20,7 +20,7 @@ const routeMetadata = getStaticRouteMetadata("/now/");
           class="text-link"
           target="_blank"
           rel="noopener noreferrer">UST</a
-        >, writing Java and Spring Boot.
+        >, writing Java.
       </p>
 
       <p style="color:var(--color-muted-foreground)">
@@ -29,16 +29,15 @@ const routeMetadata = getStaticRouteMetadata("/now/");
           class="text-link"
           target="_blank"
           rel="noopener noreferrer">Interleaf</a
-        >, a client-side PDF editor. Also early days on something new for the CLI. Not ready to
-        say much yet.
+        >, a client-side PDF editor.
       </p>
 
       <p style="color:var(--color-muted-foreground)">
         Playing — <a
-          href="https://store.steampowered.com/app/365590/Tom_Clancys_The_Division/"
+          href="https://store.steampowered.com/app/2221490/Tom_Clancys_The_Division_2/"
           class="text-link"
           target="_blank"
-          rel="noopener noreferrer">The Division</a
+          rel="noopener noreferrer">The Division 2</a
         > and <a
           href="https://store.steampowered.com/app/2000950/Call_of_Duty_Modern_Warfare/"
           class="text-link"
@@ -48,12 +47,21 @@ const routeMetadata = getStaticRouteMetadata("/now/");
       </p>
 
       <p style="color:var(--color-muted-foreground)">
-        Reading — <a
-          href="https://www.goodreads.com/book/show/36812946-deep-work"
+        Watching — <a
+          href="https://anilist.co/anime/182255/Sousou-no-Frieren-2nd-Season"
           class="text-link"
           target="_blank"
-          rel="noopener noreferrer">Deep Work</a
-        > by Cal Newport.
+          rel="noopener noreferrer">Frieren</a
+        > season 2.
+      </p>
+
+      <p style="color:var(--color-muted-foreground)">
+        Reading — <a
+          href="https://www.goodreads.com/book/show/55710822-better-than-the-movies"
+          class="text-link"
+          target="_blank"
+          rel="noopener noreferrer">Better Than the Movies</a
+        > by Lynn Painter.
       </p>
     </Container>
   </PageShell>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the `/now` page with current activities:

- **Work** — Java only (removed Spring Boot mention)
- **Building** — Interleaf only (removed CLI project teaser)
- **Playing** — The Division 2 (replaces The Division)
- **Watching** — Frieren season 2 (AniList link)
- **Reading** — *Better Than the Movies* by Lynn Painter (replaces *Deep Work*)

Also updates the "Last updated" date to August 2026.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0071e-ec3e-7cc9-a3cc-f37bca019e89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0071e-ec3e-7cc9-a3cc-f37bca019e89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

