### PR TITLE
fix: limit list row hover to fine-pointer devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this site are documented in this file.
 
 ## Unreleased
 
+### Fixed — 2026-08-18
+
+- Limit writing and project list row hover backgrounds to fine-pointer devices so
+  touch scrolling no longer leaves a stuck highlight on mobile.
+
 ### Changed — 2026-08-15
 
 - Refresh the now page: work (Java only), building (Interleaf only), playing

--- a/src/components/ContentCard.astro
+++ b/src/components/ContentCard.astro
@@ -33,8 +33,10 @@ const { title, description, href, meta, class: className } = Astro.props;
     margin-inline: calc(-1 * var(--page-inline));
     padding-inline: var(--page-inline);
   }
-  .ledger-row:hover {
-    background-color: var(--color-surface-strong);
+  @media (hover: hover) and (pointer: fine) {
+    .ledger-row:hover {
+      background-color: var(--color-surface-strong);
+    }
   }
   .ledger-title {
     font-size: var(--text-base);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On touch devices, scrolling over writing/project list rows can leave a row highlighted as if it were hovered. This wraps the ledger row hover background in a fine-pointer media query so it only applies on desktop mouse input.

## Problem

Writing and projects list items use `ContentCard`, which applies a background color on `:hover`. Touch browsers synthesize hover when a finger passes over a link during scroll, and that state can persist until another tap — making one row look "selected" on mobile.

## Fix

Scope `.ledger-row:hover` to `@media (hover: hover) and (pointer: fine)` so the highlight only appears when the primary input can hover with a fine pointer (mouse/trackpad).

## Test plan

- [x] `bun run verify`
- [ ] On mobile/touch: scroll writing and projects lists — no row should stay highlighted
- [ ] On desktop: hover list rows — background highlight still appears
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a015c3-05af-7c1e-948e-f15c1bf5a7f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a015c3-05af-7c1e-948e-f15c1bf5a7f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

