### PR TITLE
fix: prevent layout shift on initial page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this site are documented in this file.
 
 ### Fixed — 2026-08-18
 
+- Inline critical design tokens and base styles so layout no longer shifts while the
+  main stylesheet loads on hard reload.
+- Preload IBM Plex Sans and add a metric-matched fallback font to reduce text reflow
+  when the webfont finishes loading.
 - Limit writing and project list row hover backgrounds to fine-pointer devices so
   touch scrolling no longer leaves a stuck highlight on mobile.
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,7 +3,11 @@ import SEO from "@/components/seo/SEO.astro";
 import JsonLd from "@/components/seo/JsonLd.astro";
 import type { SEOProps } from "@/components/seo/SEO.astro";
 import type { JsonLdProps } from "@/components/seo/JsonLd.astro";
+import baseCss from "@/styles/base.css?raw";
+import tokensCss from "@/styles/tokens.css?raw";
 import "@/styles/global.css";
+
+const criticalCss = `${tokensCss}\n${baseCss}`;
 
 interface Props extends SEOProps {
   title?: string;
@@ -37,6 +41,15 @@ const resolvedJsonLd = jsonLd ?? {
     <meta name="theme-color" content="#111111" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link
+      rel="preload"
+      href="/fonts/IBMPlexSansVar-Roman.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+
+    <style is:inline set:html={criticalCss}></style>
 
     <!-- SEO Meta Tags -->
     <SEO

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,64 @@
+/* Base element styles — inlined for first paint, then loaded again via global.css. */
+
+html {
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  line-height: var(--leading-text);
+  font-size: var(--text-base);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-wrap: balance;
+  line-height: var(--leading-heading);
+  text-align: left;
+  font-weight: 500;
+}
+
+p {
+  text-wrap: pretty;
+  text-align: left;
+}
+
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,4 +1,13 @@
 @font-face {
+  font-family: "IBM Plex Sans Fallback";
+  src: local("Arial");
+  size-adjust: 97.44%;
+  ascent-override: 102.5%;
+  descent-override: 27.5%;
+  line-gap-override: 0%;
+}
+
+@font-face {
   font-family: "IBM Plex Sans";
   src: url("/fonts/IBMPlexSansVar-Roman.woff2") format("woff2");
   font-weight: 100 700;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,131 +1,11 @@
 @import "./fonts.css";
+@import "./tokens.css";
+@import "./base.css";
 
 /* ==========================================================================
    Swiss Style Design System
    Minimal, dark-only, accent-less. Neutral grays in OKLCH.
    ========================================================================== */
-
-:root {
-  /* Typography */
-  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
-  --font-mono:
-    "IBM Plex Mono", ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas,
-    "DejaVu Sans Mono", monospace;
-
-  /* Color palette — neutral grays, OKLCH, dark only */
-  --color-bg: oklch(14.5% 0 0);
-  --color-text: oklch(98.5% 0 0);
-  --color-border: oklch(25% 0 0);
-
-  /* Semantic tokens */
-  --color-background: var(--color-bg);
-  --color-foreground: var(--color-text);
-  --color-muted-foreground: color-mix(in oklch, var(--color-text) 60%, transparent);
-
-  /* Surface tokens */
-  --color-surface: color-mix(in oklch, var(--color-text) 6%, transparent);
-  --color-surface-strong: color-mix(in oklch, var(--color-text) 8%, transparent);
-  --color-text-muted: color-mix(in oklch, var(--color-text) 80%, transparent);
-
-  /* Fluid type scale — Utopia-inspired, tuned for a narrow personal site */
-  --step--1: clamp(0.875rem, 0.8519rem + 0.1127vw, 0.9375rem);
-  --step-0: clamp(1rem, 0.9538rem + 0.2255vw, 1.125rem);
-  --step-1: clamp(1.125rem, 1.0418rem + 0.4059vw, 1.35rem);
-  --step-2: clamp(1.2656rem, 1.1346rem + 0.6392vw, 1.62rem);
-  --step-3: clamp(1.4238rem, 1.2309rem + 0.941vw, 1.944rem);
-
-  /* Type aliases */
-  --heading-1: var(--step-3);
-  --text-xs: var(--step--1);
-  --text-sm: var(--step--1);
-  --text-base: var(--step-0);
-  --text-lg: var(--step-1);
-  --text-xl: var(--step-2);
-  --text-2xl: var(--step-3);
-  --text-3xl: var(--step-3);
-  --text-4xl: var(--step-3);
-
-  /* Line-height */
-  --leading-text: calc(0.65rem + 1em);
-  --leading-heading: calc(0.35rem + 1em);
-  --leading-none: 1;
-
-  /* Fluid spacing scale */
-  --space-3xs: clamp(0.25rem, 0.2269rem + 0.1127vw, 0.3125rem);
-  --space-2xs: clamp(0.5rem, 0.4769rem + 0.1127vw, 0.5625rem);
-  --space-xs: clamp(0.75rem, 0.7038rem + 0.2255vw, 0.875rem);
-  --space-s: clamp(1rem, 0.9538rem + 0.2255vw, 1.125rem);
-  --space-m: clamp(1.5rem, 1.4307rem + 0.3382vw, 1.6875rem);
-  --space-l: clamp(2rem, 1.9076rem + 0.451vw, 2.25rem);
-  --space-xl: clamp(3rem, 2.8613rem + 0.6764vw, 3.375rem);
-  --space-2xl: clamp(4rem, 3.8151rem + 0.9019vw, 4.5rem);
-
-  /* Semantic rhythm */
-  --page-inline: var(--space-m);
-  --page-block-start: clamp(5rem, 4.5377rem + 2.255vw, 6.25rem);
-  --page-block-end: var(--space-2xl);
-  --title-subtitle-gap: var(--space-2xs);
-  --section-gap: var(--space-m);
-  --content-gap: var(--space-l);
-  --measure: 40rem;
-
-  /* Compatibility aliases while components migrate to semantic tokens */
-  --spacing-1: var(--space-3xs);
-  --spacing-2: var(--space-2xs);
-  --spacing-3: var(--space-xs);
-  --spacing-4: var(--space-s);
-  --spacing-6: var(--space-m);
-  --spacing-8: var(--space-l);
-  --spacing-12: var(--space-xl);
-  --spacing-16: var(--space-2xl);
-
-  /* Border tokens */
-  --border-width: 1px;
-
-  /* Motion tokens */
-  --transition-base: 150ms ease;
-  --letter-spacing-uppercase: 0.04em;
-  color-scheme: dark;
-}
-
-/* ==========================================================================
-   Base Styles
-   ========================================================================== */
-html {
-  box-sizing: border-box;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: inherit;
-}
-
-body,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-figure,
-blockquote,
-dl,
-dd {
-  margin: 0;
-}
-
-body {
-  font-family: var(--font-sans);
-  background-color: var(--color-bg);
-  color: var(--color-text);
-  line-height: var(--leading-text);
-  font-size: var(--text-base);
-}
 
 a {
   text-decoration: none;
@@ -155,34 +35,6 @@ select,
 textarea,
 summary {
   touch-action: manipulation;
-}
-
-/* Typography — Swiss hierarchy through opacity, not weight */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  text-wrap: balance;
-  line-height: var(--leading-heading);
-  text-align: left;
-  font-weight: 500;
-}
-
-p {
-  text-wrap: pretty;
-  text-align: left;
-}
-
-p,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  overflow-wrap: break-word;
 }
 
 /* ==========================================================================

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,84 @@
+/* Design tokens — shared by critical inline CSS and the main stylesheet. */
+
+:root {
+  /* Typography */
+  --font-sans: "IBM Plex Sans", "IBM Plex Sans Fallback", system-ui, sans-serif;
+  --font-mono:
+    "IBM Plex Mono", ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas,
+    "DejaVu Sans Mono", monospace;
+
+  /* Color palette — neutral grays, OKLCH, dark only */
+  --color-bg: oklch(14.5% 0 0);
+  --color-text: oklch(98.5% 0 0);
+  --color-border: oklch(25% 0 0);
+
+  /* Semantic tokens */
+  --color-background: var(--color-bg);
+  --color-foreground: var(--color-text);
+  --color-muted-foreground: color-mix(in oklch, var(--color-text) 60%, transparent);
+
+  /* Surface tokens */
+  --color-surface: color-mix(in oklch, var(--color-text) 6%, transparent);
+  --color-surface-strong: color-mix(in oklch, var(--color-text) 8%, transparent);
+  --color-text-muted: color-mix(in oklch, var(--color-text) 80%, transparent);
+
+  /* Fluid type scale — Utopia-inspired, tuned for a narrow personal site */
+  --step--1: clamp(0.875rem, 0.8519rem + 0.1127vw, 0.9375rem);
+  --step-0: clamp(1rem, 0.9538rem + 0.2255vw, 1.125rem);
+  --step-1: clamp(1.125rem, 1.0418rem + 0.4059vw, 1.35rem);
+  --step-2: clamp(1.2656rem, 1.1346rem + 0.6392vw, 1.62rem);
+  --step-3: clamp(1.4238rem, 1.2309rem + 0.941vw, 1.944rem);
+
+  /* Type aliases */
+  --heading-1: var(--step-3);
+  --text-xs: var(--step--1);
+  --text-sm: var(--step--1);
+  --text-base: var(--step-0);
+  --text-lg: var(--step-1);
+  --text-xl: var(--step-2);
+  --text-2xl: var(--step-3);
+  --text-3xl: var(--step-3);
+  --text-4xl: var(--step-3);
+
+  /* Line-height */
+  --leading-text: calc(0.65rem + 1em);
+  --leading-heading: calc(0.35rem + 1em);
+  --leading-none: 1;
+
+  /* Fluid spacing scale */
+  --space-3xs: clamp(0.25rem, 0.2269rem + 0.1127vw, 0.3125rem);
+  --space-2xs: clamp(0.5rem, 0.4769rem + 0.1127vw, 0.5625rem);
+  --space-xs: clamp(0.75rem, 0.7038rem + 0.2255vw, 0.875rem);
+  --space-s: clamp(1rem, 0.9538rem + 0.2255vw, 1.125rem);
+  --space-m: clamp(1.5rem, 1.4307rem + 0.3382vw, 1.6875rem);
+  --space-l: clamp(2rem, 1.9076rem + 0.451vw, 2.25rem);
+  --space-xl: clamp(3rem, 2.8613rem + 0.6764vw, 3.375rem);
+  --space-2xl: clamp(4rem, 3.8151rem + 0.9019vw, 4.5rem);
+
+  /* Semantic rhythm */
+  --page-inline: var(--space-m);
+  --page-block-start: clamp(5rem, 4.5377rem + 2.255vw, 6.25rem);
+  --page-block-end: var(--space-2xl);
+  --title-subtitle-gap: var(--space-2xs);
+  --section-gap: var(--space-m);
+  --content-gap: var(--space-l);
+  --measure: 40rem;
+
+  /* Compatibility aliases while components migrate to semantic tokens */
+  --spacing-1: var(--space-3xs);
+  --spacing-2: var(--space-2xs);
+  --spacing-3: var(--space-xs);
+  --spacing-4: var(--space-s);
+  --spacing-6: var(--space-m);
+  --spacing-8: var(--space-l);
+  --spacing-12: var(--space-xl);
+  --spacing-16: var(--space-2xl);
+
+  /* Border tokens */
+  --border-width: 1px;
+
+  /* Motion tokens */
+  --transition-base: 150ms ease;
+  --letter-spacing-uppercase: 0.04em;
+  color-scheme: dark;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On hard reload, the homepage text appeared slightly misaligned and then jumped into place once the stylesheet loaded. The same pattern could affect any page that relies on CSS custom properties in inline styles.

## Root cause

Layout spacing and typography are driven by inline `style` attributes that reference design tokens such as `--page-block-start`, `--heading-1`, and `--measure`. Those tokens live in the external stylesheet, so on first paint the browser treats the `var()` values as invalid and ignores them. When the stylesheet arrives, padding, max-width, and heading size snap into place.

A secondary shift came from `font-display: swap`, where IBM Plex Sans replaces the system fallback with different metrics.

## Solution

- Extract shared design tokens (`tokens.css`) and base element styles (`base.css`).
- Inline tokens + base styles in `Layout.astro` so custom properties resolve on the first paint.
- Preload the primary IBM Plex Sans font file.
- Add a metric-matched Arial fallback (`IBM Plex Sans Fallback`) to reduce reflow when the webfont finishes loading.

## Testing

- `bun run verify` passes (type-check, lint, format, tests, build).
- Built HTML includes inline critical CSS and a font preload link before the external stylesheet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a015cb-b37f-78fa-9085-d96c759ac8e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a015cb-b37f-78fa-9085-d96c759ac8e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

